### PR TITLE
Cmr provider hotfix

### DIFF
--- a/ecco_pipeline/conf/ds_configs/AQUARIUS_L3_SSS_SMI_MONTHLY_V5.yaml
+++ b/ecco_pipeline/conf/ds_configs/AQUARIUS_L3_SSS_SMI_MONTHLY_V5.yaml
@@ -9,7 +9,7 @@ cmr_short_name: AQUARIUS_L3_SSS_SMI_MONTHLY_V5
 cmr_version: '5'
 regex: '\d{7}'
 filename_date_fmt: '%Y%j'
-provider: 'podaac-opendap'
+provider: 'archive.podaac'
 
 # Metadata
 aggregated: false # if data is available aggregated

--- a/ecco_pipeline/conf/ds_configs/AVHRR_OI-NCEI-L4-GLOB-v2.0.yaml
+++ b/ecco_pipeline/conf/ds_configs/AVHRR_OI-NCEI-L4-GLOB-v2.0.yaml
@@ -9,7 +9,7 @@ cmr_short_name: "AVHRR_OI-NCEI-L4-GLOB-v2.0"
 cmr_version: "2.0"
 regex: '\d{8}'
 filename_date_fmt: '%Y%m%d'
-provider: 'podaac-opendap'
+provider: 'archive.podaac'
 
 # Metadata
 aggregated: false # if data is available aggregated


### PR DESCRIPTION
Dataset configs contained unsupported data file providers, breaking data harvesting. Provider in config has been updated to archive.podaac.