### PR TITLE
added logic to replace failed tx granules with empty records

### DIFF
--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -95,6 +95,7 @@ class Aggregation():
                             break
                 else:
                     grid_years.append(year)
+
             years[grid_name] = grid_years
         return years
 


### PR DESCRIPTION
aggregation can fail because of bad transformed granules. now we check that the tx granules have success_b=True before aggregating them. 