### PR TITLE
Log overhaul

### DIFF
--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -1,3 +1,4 @@
+from multiprocessing import current_process
 from typing import Iterable
 import numpy as np
 
@@ -6,6 +7,9 @@ from collections import defaultdict
 from dataset import Dataset
 from utils import solr_utils
 import logging
+
+logger = logging.getLogger(str(current_process().pid))
+
 
 class Aggregation(Dataset):
     '''
@@ -33,6 +37,6 @@ class Aggregation(Dataset):
         fq = [f'dataset_s:{self.ds_name}', 'type_s:dataset']
         ds_meta = solr_utils.solr_query(fq)[0]
         if 'start_date_dt' not in ds_meta:
-            logging.info('No transformed granules to aggregate.')
+            logger.info('No transformed granules to aggregate.')
             raise Exception('No transformed granules to aggregate.')
         self.ds_meta = ds_meta

--- a/ecco_pipeline/conf/ds_configs/L3_DEBIAS_LOCEAN_v8_q09.yaml
+++ b/ecco_pipeline/conf/ds_configs/L3_DEBIAS_LOCEAN_v8_q09.yaml
@@ -3,11 +3,8 @@ start: 19800101T00:00:01Z # yyyymmddThh:mm:ssZ
 end: "NOW" # yyyymmddThh:mm:ssZ
 
 # Provider specifications
-harvester_type: ifremer_ftp
-host: ftp.ifremer.fr
-user: ext-catds-cecos-locean # does not change
-password: catds2010
-ddir: Ocean_products/L3_DEBIAS_LOCEAN/L3_DEBIAS_LOCEAN_v8/debiasedSSS_09days_v8/
+harvester_type: catds
+ddir: L3_DEBIAS_LOCEAN/L3_DEBIAS_LOCEAN_v8/debiasedSSS_09days_v8
 filename_date_fmt: "%Y%m%d"
 filename_date_regex: \d{8}
 filename_filter: "" # string to match for filenames to download ex: polstere-100_multi

--- a/ecco_pipeline/conf/ds_configs/L3_DEBIAS_LOCEAN_v8_q18.yaml
+++ b/ecco_pipeline/conf/ds_configs/L3_DEBIAS_LOCEAN_v8_q18.yaml
@@ -3,11 +3,8 @@ start: 19800101T00:00:01Z # yyyymmddThh:mm:ssZ
 end: NOW # yyyymmddThh:mm:ssZ
 
 # Provider specifications
-harvester_type: ifremer_ftp
-host: ftp.ifremer.fr
-user: ext-catds-cecos-locean # does not change
-password: catds2010
-ddir: Ocean_products/L3_DEBIAS_LOCEAN/L3_DEBIAS_LOCEAN_v8/debiasedSSS_18days_v8/
+harvester_type: catds
+ddir: L3_DEBIAS_LOCEAN/L3_DEBIAS_LOCEAN_v8/debiasedSSS_18days_v8/
 filename_date_fmt: "%Y%m%d"
 filename_date_regex: \d{8}
 filename_filter: "" # string to match for filenames to download ex: polstere-100_multi

--- a/ecco_pipeline/harvesters/catds_harvester.py
+++ b/ecco_pipeline/harvesters/catds_harvester.py
@@ -1,0 +1,71 @@
+import logging
+import os
+from datetime import datetime
+from typing import Iterable
+
+import requests
+from harvesters.enumeration.catds_enumerator import search_catds, CATDSGranule
+from harvesters.granule import Granule
+from harvesters.harvester import Harvester
+from utils.file_utils import get_date
+
+logger = logging.getLogger('pipeline')
+
+
+class CATDS_Harvester(Harvester):
+    
+    def __init__(self, config: dict):
+        Harvester.__init__(self, config)
+        self.catds_granules: Iterable[CATDSGranule] = search_catds(self)
+    
+    def fetch(self):
+        for catds_granule in self.catds_granules:
+            filename = catds_granule.url.split('/')[-1]
+            # Get date from filename and convert to dt object
+            date = get_date(self.filename_date_regex, filename)
+            dt = datetime.strptime(date, self.filename_date_fmt)
+            if not (self.start <= dt) and (self.end >= dt):
+                continue
+            
+            year = str(dt.year)
+
+            local_fp = f'{self.target_dir}{year}/{filename}'
+
+            if not os.path.exists(f'{self.target_dir}{year}/'):
+                os.makedirs(f'{self.target_dir}{year}/')
+                
+            if self.check_update(filename, catds_granule.mod_time):
+                success = True
+                granule = Granule(self.ds_name, local_fp, dt, catds_granule.mod_time, catds_granule.url)
+                
+                if self.need_to_download(granule):
+                    logger.info(f'Downloading {filename} to {local_fp}')
+                    try:
+                        self.dl_file(catds_granule.url, local_fp)
+                    except:
+                        success = False
+                else:
+                    logger.debug(f'{filename} already downloaded and up to date')
+                    
+                granule.update_item(self.solr_docs, success)
+                granule.update_descendant(self.descendant_docs, success)
+                self.updated_solr_docs.extend(granule.get_solr_docs())
+        logger.info(f'Downloading {self.ds_name} complete')
+        
+    
+    def dl_file(self, src: str, dst: str):
+        r = requests.get(src)
+        r.raise_for_status()
+        open(dst, 'wb').write(r.content)
+
+
+def harvester(config: dict) -> str:
+    """
+    Uses CMR search to find granules within date range given in harvester_config.yaml.
+    Creates (or updates) Solr entries for dataset, harvested granule, and descendants.
+    """
+
+    harvester = CATDS_Harvester(config)    
+    harvester.fetch()
+    harvesting_status = harvester.post_fetch()
+    return harvesting_status

--- a/ecco_pipeline/harvesters/enumeration/catds_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/catds_enumerator.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+import logging
+import requests
+import os
+from bs4 import BeautifulSoup
+from datetime import datetime
+
+from harvesters.harvester import Harvester
+
+logger = logging.getLogger('pipeline')
+
+
+CATDS_URL = 'https://data.catds.fr/cecos-locean/Ocean_products/'
+    
+def search_catds(harvester: Harvester):
+    logger.info(f'Searching CATDS for {harvester.ds_name} granules...')   
+    all_granules = []
+    ds_url = os.path.join(CATDS_URL, harvester.ddir)
+    r = requests.get(ds_url)
+    data = BeautifulSoup(r.text, "html.parser")
+    for l in data.find_all("tr")[3:-1]:
+        tokens = l.find_all("td")
+        url = os.path.join(ds_url, tokens[1].find("a")['href'])
+        mod_time = datetime.strptime(tokens[2].text, '%Y-%m-%d %H:%M  ')
+        all_granules.append(CATDSGranule(url, mod_time))
+    logger.info(f'Found {len(all_granules)} possible granules')
+    return all_granules
+
+@dataclass
+class CATDSGranule():
+    url: str
+    mod_time: datetime

--- a/ecco_pipeline/harvesters/enumeration/cmr_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/cmr_enumerator.py
@@ -8,6 +8,7 @@ import requests
 
 from harvesters.harvester import Harvester
 
+logger = logging.getLogger('pipeline')
 
 CMR_GRANULE_URL = 'https://cmr.earthdata.nasa.gov/search/granules.json?&sort_key[]=start_date&sort_key[]=producer_granule_id&scroll=true&page_size=2000'
 
@@ -68,7 +69,7 @@ def cmr_filter_urls(search_results, provider):
 
 
 def cmr_search(harvester: Harvester, filename_filter=''):
-    logging.info(f'Querying CMR for concept id {harvester.cmr_concept_id}')
+    logger.info(f'Querying CMR for concept id {harvester.cmr_concept_id}')
     time_start = harvester.start.strftime('%Y-%m-%dT%H:%M:%SZ')
     time_end = harvester.end.strftime('%Y-%m-%dT%H:%M:%SZ')
 

--- a/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
@@ -7,10 +7,13 @@ from datetime import datetime
 
 from harvesters.harvester import Harvester
 
+logger = logging.getLogger('pipeline')
+
+
 NSIDC_URL = 'https://noaadata.apps.nsidc.org/NOAA/'
     
 def search_nsidc(harvester: Harvester):
-    logging.info(f'Searching NSIDC for {harvester.ds_name} granules...')
+    logger.info(f'Searching NSIDC for {harvester.ds_name} granules...')
     date_range = range(harvester.start.year, harvester.end.year + 1)
     all_granules = []
     for hemi in ['north', 'south']:
@@ -30,7 +33,7 @@ def search_nsidc(harvester: Harvester):
                 mod_time = datetime.strptime(tokens[0] + ' ' + tokens[1], '%d-%b-%Y %H:%M')
                 size = tokens[2]
                 all_granules.append(NSIDCGranule(url, mod_time, size))
-    logging.info(f'Found {len(all_granules)} possible granules')
+    logger.info(f'Found {len(all_granules)} possible granules')
     return all_granules
 
 @dataclass

--- a/ecco_pipeline/harvesters/harvester.py
+++ b/ecco_pipeline/harvesters/harvester.py
@@ -43,6 +43,9 @@ class Harvester(Dataset):
             self.password = config.get('password')
             self.ddir = config.get('ddir')
             self.filename_filter = config.get('filename_filter')
+        elif self.harvester_type == 'catds':
+            self.ddir = config.get('ddir')
+            
       
     def fetch(self):
         raise NotImplementedError

--- a/ecco_pipeline/harvesters/harvester.py
+++ b/ecco_pipeline/harvesters/harvester.py
@@ -6,6 +6,7 @@ from dataset import Dataset
 from utils import solr_utils
 from conf.global_settings import OUTPUT_DIR
 
+logger = logging.getLogger('pipeline')
 
 class Harvester(Dataset):
     
@@ -119,12 +120,12 @@ class Harvester(Dataset):
         if self.updated_solr_docs:
             r = solr_utils.solr_update(self.updated_solr_docs, r=True)
             if r.status_code == 200:
-                logging.debug(
+                logger.debug(
                     'Successfully created or updated Solr harvested documents')
             else:
-                logging.exception('Failed to create Solr harvested documents')
+                logger.exception('Failed to create Solr harvested documents')
         else:
-            logging.debug('No downloads required.')
+            logger.debug('No downloads required.')
             
         harvesting_status = self.harvester_status()
         
@@ -178,9 +179,9 @@ class Harvester(Dataset):
         r = solr_utils.solr_update([ds_meta], r=True)
 
         if r.status_code == 200:
-            logging.debug('Successfully updated Solr dataset document')
+            logger.debug('Successfully updated Solr dataset document')
         else:
-            logging.exception('Failed to update Solr dataset document')
+            logger.exception('Failed to update Solr dataset document')
         return harvesting_status
     
     def harvester_status(self) -> str:

--- a/ecco_pipeline/harvesters/nsidc_harvester.py
+++ b/ecco_pipeline/harvesters/nsidc_harvester.py
@@ -9,6 +9,8 @@ from harvesters.granule import Granule
 from harvesters.harvester import Harvester
 from utils.file_utils import get_date
 
+logger = logging.getLogger('pipeline')
+
 
 class NSIDC_Harvester(Harvester):
     
@@ -37,18 +39,18 @@ class NSIDC_Harvester(Harvester):
                 granule = Granule(self.ds_name, local_fp, dt, nsidc_granule.mod_time, nsidc_granule.url)
                 
                 if self.need_to_download(granule):
-                    logging.info(f'Downloading {filename} to {local_fp}')
+                    logger.info(f'Downloading {filename} to {local_fp}')
                     try:
                         self.dl_file(nsidc_granule.url, local_fp)
                     except:
                         success = False
                 else:
-                    logging.debug(f'{filename} already downloaded and up to date')
+                    logger.debug(f'{filename} already downloaded and up to date')
                     
                 granule.update_item(self.solr_docs, success)
                 granule.update_descendant(self.descendant_docs, success)
                 self.updated_solr_docs.extend(granule.get_solr_docs())
-        logging.info(f'Downloading {self.ds_name} complete')
+        logger.info(f'Downloading {self.ds_name} complete')
         
     
     def dl_file(self, src: str, dst: str):

--- a/ecco_pipeline/run_pipeline.py
+++ b/ecco_pipeline/run_pipeline.py
@@ -48,7 +48,7 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def show_menu(grids_to_use: List[str], user_cpus: int, log_filename: str):
+def show_menu(grids_to_use: List[str], user_cpus: int, log_dir: str):
     while True:
         print('\n===== ECCO PREPROCESSING PIPELINE =====')
         print('\n------------- OPTIONS -------------')
@@ -74,8 +74,8 @@ def show_menu(grids_to_use: List[str], user_cpus: int, log_filename: str):
     if chosen_option == '1':
         for ds in datasets:
             run_harvester([ds])
-            run_transformation([ds], user_cpus, grids_to_use, log_filename)
-            run_aggregation([ds], user_cpus, grids_to_use, log_filename)
+            run_transformation([ds], user_cpus, grids_to_use, log_dir)
+            run_aggregation([ds], user_cpus, grids_to_use, log_dir)
 
     # Run harvester
     elif chosen_option == '2':
@@ -85,7 +85,7 @@ def show_menu(grids_to_use: List[str], user_cpus: int, log_filename: str):
     elif chosen_option == '3':
         for ds in datasets:
             run_harvester([ds])
-            run_transformation([ds], user_cpus, grids_to_use, log_filename)
+            run_transformation([ds], user_cpus, grids_to_use, log_dir)
 
     # Manually enter dataset and pipeline step(s)
     elif chosen_option == '4':
@@ -126,13 +126,13 @@ def show_menu(grids_to_use: List[str], user_cpus: int, log_filename: str):
         if 'harvest' in wanted_steps:
             run_harvester([wanted_ds])
         if 'transform' in wanted_steps:
-            run_transformation([wanted_ds], user_cpus, grids_to_use, log_filename)
+            run_transformation([wanted_ds], user_cpus, grids_to_use, log_dir)
         if 'aggregate' in wanted_steps:
-            run_aggregation([wanted_ds], user_cpus, grids_to_use, log_filename)
+            run_aggregation([wanted_ds], user_cpus, grids_to_use, log_dir)
         if wanted_steps == 'all':
             run_harvester([wanted_ds])
-            run_transformation([wanted_ds], user_cpus, grids_to_use, log_filename)
-            run_aggregation([wanted_ds], user_cpus, grids_to_use, log_filename)
+            run_transformation([wanted_ds], user_cpus, grids_to_use, log_dir)
+            run_aggregation([wanted_ds], user_cpus, grids_to_use, log_dir)
 
 
 def run_harvester(datasets: List[str]):
@@ -161,27 +161,27 @@ def run_harvester(datasets: List[str]):
             logging.exception(f'{ds} harvesting failed. {e}')
 
 
-def run_transformation(datasets: List[str], user_cpus: int, grids_to_use: List[str], log_filename: str):
+def run_transformation(datasets: List[str], user_cpus: int, grids_to_use: List[str], log_dir: str):
     for ds in datasets:
         try:
             logging.info(f'Beginning transformations on {ds}')
             with open(Path(f'conf/ds_configs/{ds}.yaml'), 'r') as stream:
                 config = yaml.load(stream, yaml.Loader)
 
-            status = check_transformations.main(config, user_cpus, grids_to_use, log_filename)
+            status = check_transformations.main(config, user_cpus, grids_to_use, log_dir)
             logging.info(f'{ds} transformation complete. {status}')
         except:
             logging.exception(f'{ds} transformation failed.')
 
 
-def run_aggregation(datasets: List[str], user_cpus: int, grids_to_use: List[str], log_filename: str):
+def run_aggregation(datasets: List[str], user_cpus: int, grids_to_use: List[str], log_dir: str):
     for ds in datasets:
         try:
             logging.info(f'Beginning aggregation on {ds}')
             with open(Path(f'conf/ds_configs/{ds}.yaml'), 'r') as stream:
                 config = yaml.load(stream, yaml.Loader)
 
-            status = aggregation(config, user_cpus, grids_to_use, log_filename)
+            status = aggregation(config, user_cpus, grids_to_use, log_dir)
             logging.info(f'{ds} aggregation complete. {status}')
         except Exception as e:
             logging.exception(f'{ds} aggregation failed: {e}')
@@ -190,5 +190,5 @@ def run_aggregation(datasets: List[str], user_cpus: int, grids_to_use: List[str]
 if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
-    grids_to_use, user_cpus, log_filename = init_pipeline.init_pipeline(args)
-    show_menu(grids_to_use, user_cpus, log_filename)
+    grids_to_use, user_cpus, log_dir = init_pipeline.init_pipeline(args)
+    show_menu(grids_to_use, user_cpus, log_dir)

--- a/ecco_pipeline/run_pipeline.py
+++ b/ecco_pipeline/run_pipeline.py
@@ -1,7 +1,7 @@
 import argparse
 import importlib
-import logging
 from glob import glob
+import logging
 from multiprocessing import cpu_count
 import os
 from pathlib import Path
@@ -11,7 +11,7 @@ import yaml
 
 from aggregations.aggregate import aggregation
 from transformations import check_transformations
-from utils import init_pipeline
+from utils import init_pipeline, log_config
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -48,7 +48,7 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def show_menu(grids_to_use: List[str], user_cpus: int, log_dir: str):
+def show_menu(grids_to_use: List[str], user_cpus: int):
     while True:
         print('\n===== ECCO PREPROCESSING PIPELINE =====')
         print('\n------------- OPTIONS -------------')
@@ -74,8 +74,8 @@ def show_menu(grids_to_use: List[str], user_cpus: int, log_dir: str):
     if chosen_option == '1':
         for ds in datasets:
             run_harvester([ds])
-            run_transformation([ds], user_cpus, grids_to_use, log_dir)
-            run_aggregation([ds], user_cpus, grids_to_use, log_dir)
+            run_transformation([ds], user_cpus, grids_to_use)
+            run_aggregation([ds], user_cpus, grids_to_use)
 
     # Run harvester
     elif chosen_option == '2':
@@ -85,7 +85,7 @@ def show_menu(grids_to_use: List[str], user_cpus: int, log_dir: str):
     elif chosen_option == '3':
         for ds in datasets:
             run_harvester([ds])
-            run_transformation([ds], user_cpus, grids_to_use, log_dir)
+            run_transformation([ds], user_cpus, grids_to_use)
 
     # Manually enter dataset and pipeline step(s)
     elif chosen_option == '4':
@@ -126,19 +126,19 @@ def show_menu(grids_to_use: List[str], user_cpus: int, log_dir: str):
         if 'harvest' in wanted_steps:
             run_harvester([wanted_ds])
         if 'transform' in wanted_steps:
-            run_transformation([wanted_ds], user_cpus, grids_to_use, log_dir)
+            run_transformation([wanted_ds], user_cpus, grids_to_use)
         if 'aggregate' in wanted_steps:
-            run_aggregation([wanted_ds], user_cpus, grids_to_use, log_dir)
+            run_aggregation([wanted_ds], user_cpus, grids_to_use)
         if wanted_steps == 'all':
             run_harvester([wanted_ds])
-            run_transformation([wanted_ds], user_cpus, grids_to_use, log_dir)
-            run_aggregation([wanted_ds], user_cpus, grids_to_use, log_dir)
+            run_transformation([wanted_ds], user_cpus, grids_to_use)
+            run_aggregation([wanted_ds], user_cpus, grids_to_use)
 
 
 def run_harvester(datasets: List[str]):
     for ds in datasets:
         try:
-            logging.info(f'Beginning harvesting {ds}')
+            logger.info(f'Beginning harvesting {ds}')
 
             with open(Path(f'conf/ds_configs/{ds}.yaml'), 'r') as stream:
                 config = yaml.load(stream, yaml.Loader)
@@ -146,49 +146,50 @@ def run_harvester(datasets: List[str]):
             try:
                 harvester_type = config['harvester_type']
             except:
-                logging.fatal(f'Harvester type missing from {ds} config. Exiting.')
+                logger.fatal(f'Harvester type missing from {ds} config. Exiting.')
                 exit()
 
             try:
                 harvester = importlib.import_module(f'harvesters.{harvester_type}_harvester')
             except Exception as e:
-                logging.error(e)
+                logger.exception(e)
                 exit()
 
             status = harvester.harvester(config)
-            logging.info(f'{ds} harvesting complete. {status}')
+            logger.info(f'{ds} harvesting complete. {status}')
         except Exception as e:
-            logging.exception(f'{ds} harvesting failed. {e}')
+            logger.exception(f'{ds} harvesting failed. {e}')
 
 
-def run_transformation(datasets: List[str], user_cpus: int, grids_to_use: List[str], log_dir: str):
+def run_transformation(datasets: List[str], user_cpus: int, grids_to_use: List[str]):
     for ds in datasets:
         try:
-            logging.info(f'Beginning transformations on {ds}')
+            logger.info(f'Beginning transformations on {ds}')
             with open(Path(f'conf/ds_configs/{ds}.yaml'), 'r') as stream:
                 config = yaml.load(stream, yaml.Loader)
 
-            status = check_transformations.main(config, user_cpus, grids_to_use, log_dir)
-            logging.info(f'{ds} transformation complete. {status}')
+            status = check_transformations.main(config, user_cpus, grids_to_use)
+            logger.info(f'{ds} transformation complete. {status}')
         except:
-            logging.exception(f'{ds} transformation failed.')
+            logger.exception(f'{ds} transformation failed.')
 
 
-def run_aggregation(datasets: List[str], user_cpus: int, grids_to_use: List[str], log_dir: str):
+def run_aggregation(datasets: List[str], user_cpus: int, grids_to_use: List[str]):
     for ds in datasets:
         try:
-            logging.info(f'Beginning aggregation on {ds}')
+            logger.info(f'Beginning aggregation on {ds}')
             with open(Path(f'conf/ds_configs/{ds}.yaml'), 'r') as stream:
                 config = yaml.load(stream, yaml.Loader)
 
-            status = aggregation(config, user_cpus, grids_to_use, log_dir)
-            logging.info(f'{ds} aggregation complete. {status}')
+            status = aggregation(config, user_cpus, grids_to_use)
+            logger.info(f'{ds} aggregation complete. {status}')
         except Exception as e:
-            logging.exception(f'{ds} aggregation failed: {e}')
+            logger.exception(f'{ds} aggregation failed: {e}')
 
 
 if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
-    grids_to_use, user_cpus, log_dir = init_pipeline.init_pipeline(args)
-    show_menu(grids_to_use, user_cpus, log_dir)
+    grids_to_use, user_cpus = init_pipeline.init_pipeline(args)
+    logger = logging.getLogger('pipeline')
+    show_menu(grids_to_use, user_cpus)

--- a/ecco_pipeline/transformations/transformation.py
+++ b/ecco_pipeline/transformations/transformation.py
@@ -12,11 +12,10 @@ from dataset import Dataset
 from conf.global_settings import OUTPUT_DIR
 from field import Field
 from utils.ecco_utils import ecco_functions, records, date_time
+from utils import log_config as log_config
 
-logger = logging.getLogger(str(current_process().pid))
 
 class Transformation(Dataset):
-
     def __init__(self, config: dict, source_file_path: str, granule_date: str):
         super().__init__(config)
         self.file_name: str = os.path.splitext(source_file_path.split('/')[-1])[0]
@@ -65,6 +64,7 @@ class Transformation(Dataset):
         return ''
 
     def apply_funcs(self, data_object, funcs: Iterable):
+        logger = logging.getLogger(str(current_process().pid))
         for func_to_run in funcs:
             logger.debug(f'Applying {func_to_run} to {self.file_name} data')
             try:
@@ -86,6 +86,8 @@ class Transformation(Dataset):
         nearest_source_index_to_target_index_i)
 
         '''
+        logger = logging.getLogger(str(current_process().pid))
+        
         grid_name = grid_ds.name
         factors_dir = f'{OUTPUT_DIR}/{self.ds_name}/transformed_products/{grid_name}/'
         factors_file = f'{grid_name}{self.hemi}_v{self.transformation_version}_factors'
@@ -131,6 +133,7 @@ class Transformation(Dataset):
         '''
         Maps source data to target grid and applies metadata
         '''
+        logger = logging.getLogger(str(current_process().pid))
 
         # initialize notes for this record
         record_notes = ''
@@ -214,6 +217,8 @@ class Transformation(Dataset):
         Function that actually performs the transformations. Returns a list of transformed
         xarray datasets, one dataset for each field being transformed for the given grid.
         """
+        logger = logging.getLogger(str(current_process().pid))
+        
         logger.info(f'Transforming {self.date} to {model_grid.name}')
 
         record_date = self.date.replace('Z', '')

--- a/ecco_pipeline/utils/config_validator.py
+++ b/ecco_pipeline/utils/config_validator.py
@@ -3,6 +3,8 @@ import logging
 from jsonschema import validate, ValidationError
 import yaml
 
+logger = logging.getLogger('pipeline')
+
 def validate_configs():
     configs = glob('conf/ds_configs/*.yaml')
     configs.sort()
@@ -11,13 +13,13 @@ def validate_configs():
         schema = yaml.load(f, Loader=yaml.Loader)
 
     for filepath in configs:
-        logging.debug(f'Validating {filepath.split("/")[-1]}')
+        logger.debug(f'Validating {filepath.split("/")[-1]}')
         with open(filepath, 'r') as f:
             config = yaml.load(f, Loader= yaml.Loader)
             try:
                 validate(config, schema)
             except ValidationError as e:
-                logging.error(e)
+                logger.error(e)
                 raise ValidationError(f'{filepath.split("/")[-1]} is malformed.')
 
 if __name__ == '__main__':

--- a/ecco_pipeline/utils/ecco_utils/ecco_functions.py
+++ b/ecco_pipeline/utils/ecco_utils/ecco_functions.py
@@ -1,4 +1,5 @@
 import logging
+from multiprocessing import current_process
 from typing import List, Tuple
 
 import numpy as np
@@ -7,6 +8,7 @@ import xarray as xr
 from aggregations.aggregation import Aggregation
 from utils.ecco_utils import date_time, records
 
+logger = logging.getLogger(str(current_process().pid))
 
 def transform_to_target_grid(source_indices_within_target_radius_i: dict,
                              num_source_indices_within_target_radius_i: list,
@@ -510,10 +512,10 @@ def G2202_mask_flagged_conc(ds: xr.Dataset) -> xr.Dataset:
     '''
     Masks out values greater than 1 in nsidc_nt_seaice_conc and cdr_seaice_conc
     '''
-    logging.debug(f'G2202 masking flagged nt pre   : {np.sum(ds["nsidc_nt_seaice_conc"].values.ravel() > 1)}')
+    logger.debug(f'G2202 masking flagged nt pre   : {np.sum(ds["nsidc_nt_seaice_conc"].values.ravel() > 1)}')
     tmpNT = np.where(ds["nsidc_nt_seaice_conc"].values.ravel() > 1, 1, 0)
     tmpCDR = np.where(ds["cdr_seaice_conc"].values.ravel() > 1, 1, 0)
-    logging.debug(f'G2202 masking flagged NDR, CDR pre: {np.sum(tmpNT), np.sum(tmpCDR)}')
+    logger.debug(f'G2202 masking flagged NDR, CDR pre: {np.sum(tmpNT), np.sum(tmpCDR)}')
 
     ds['nsidc_nt_seaice_conc'] = ds['nsidc_nt_seaice_conc'].where(ds['nsidc_nt_seaice_conc'] <= 1)
     ds['cdr_seaice_conc'] = ds['cdr_seaice_conc'].where(ds['cdr_seaice_conc'] <= 1)
@@ -524,7 +526,7 @@ def G2202_mask_flagged_conc(ds: xr.Dataset) -> xr.Dataset:
 
     tmpNT = np.where(ds["nsidc_nt_seaice_conc"].values.ravel() > 1, 1, 0)
     tmpCDR = np.where(ds["cdr_seaice_conc"].values.ravel() > 1, 1, 0)
-    logging.debug(f'G2202 masking flagged NDR, CDR post: {np.sum(tmpNT), np.sum(tmpCDR)}')
+    logger.debug(f'G2202 masking flagged NDR, CDR post: {np.sum(tmpNT), np.sum(tmpCDR)}')
 
     return ds
 

--- a/ecco_pipeline/utils/grids_to_solr.py
+++ b/ecco_pipeline/utils/grids_to_solr.py
@@ -2,8 +2,9 @@ import logging
 import os
 from datetime import datetime
 import xarray as xr
-from utils import file_utils, solr_utils
+from utils import file_utils, solr_utils, log_config
 
+logger = logging.getLogger('pipeline')
 
 def update_solr_grid(grid_name, grid_type, grid_file):
     '''
@@ -50,9 +51,9 @@ def update_solr_grid(grid_name, grid_type, grid_file):
             r = solr_utils.solr_update(update_body, r=True)
 
             if r.status_code == 200:
-                logging.debug(f'Successfully deleted Solr transformation documents for {grid_name}')
+                logger.debug(f'Successfully deleted Solr transformation documents for {grid_name}')
             else:
-                logging.exception(f'Failed to delete Solr transformation documents for {grid_name}')
+                logger.exception(f'Failed to delete Solr transformation documents for {grid_name}')
 
             # Delete previous grid's aggregations from Solr
             update_body = {
@@ -64,9 +65,9 @@ def update_solr_grid(grid_name, grid_type, grid_file):
             r = solr_utils.solr_update(update_body, r=True)
 
             if r.status_code == 200:
-                logging.debug(f'Successfully deleted Solr aggregation documents for {grid_name}')
+                logger.debug(f'Successfully deleted Solr aggregation documents for {grid_name}')
             else:
-                logging.exception(f'Failed to delete Solr aggregation documents for {grid_name}')
+                logger.exception(f'Failed to delete Solr aggregation documents for {grid_name}')
 
             # Update grid on Solr
             fq = [f'grid_name_s:{grid_name}', 'type_s:grid']
@@ -85,9 +86,9 @@ def update_solr_grid(grid_name, grid_type, grid_file):
     r = solr_utils.solr_update(update_body, r=True)
 
     if r.status_code == 200:
-        logging.debug(f'Successfully updated {grid_name} Solr grid document')
+        logger.debug(f'Successfully updated {grid_name} Solr grid document')
     else:
-        logging.error(f'Failed to update Solr {grid_name} grid document')
+        logger.error(f'Failed to update Solr {grid_name} grid document')
 
 
 def main(grids_to_use=[]):
@@ -108,20 +109,20 @@ def main(grids_to_use=[]):
         grid_name = ds.attrs['name']
         grid_type = ds.attrs['type']
         grids.append((grid_name, grid_type, grid_file))
-        logging.debug(f'Loaded {grid_name} {grid_type} {grid_file}')
+        logger.debug(f'Loaded {grid_name} {grid_type} {grid_file}')
 
     # =====================================================
     # Create Solr grid-type document for each missing grid type
     # =====================================================
     for grid_name, grid_type, grid_file in grids:
-        logging.debug(f'Uploading solr grid {grid_name} {grid_type} {grid_file}')
+        logger.debug(f'Uploading solr grid {grid_name} {grid_type} {grid_file}')
         update_solr_grid(grid_name, grid_type, grid_file)
 
     # =====================================================
     # Verify grid names supplied exist on Solr
     # =====================================================
     grids_not_in_solr = []
-    logging.debug(f'Grids to use: {grids_to_use}')
+    logger.debug(f'Grids to use: {grids_to_use}')
     for grid_name in grids_to_use:
         fq = ['type_s:grid', f'grid_name_s:{grid_name}']
         docs = solr_utils.solr_query(fq)

--- a/ecco_pipeline/utils/init_pipeline.py
+++ b/ecco_pipeline/utils/init_pipeline.py
@@ -14,70 +14,76 @@ except ImportError:
     raise ImportError('Missing global_settings.py file. See ecco_pipeline/conf/global_settings.py.example for more info.')
 
 def setup_logger(args):
-    filename = log_config.root_logging(args.log_level)
-
+    logger = log_config.mp_logging('pipeline', args.log_level)
     # Set package logging level to WARNING
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
-    return filename
+    return logger
 
 def validate_output_dir():
+    logger = logging.getLogger('pipeline')
     # Verify output directory is valid
     if not Path.is_dir(OUTPUT_DIR):
-        logging.fatal('Missing output directory. Please fill in. Exiting.')
+        logger.fatal('Missing output directory. Please fill in. Exiting.')
         exit()
-    logging.debug(f'Using output directory: {OUTPUT_DIR}')
+    logger.debug(f'Using output directory: {OUTPUT_DIR}')
 
 
 def validate_solr():
-    logging.debug(f'Using Solr collection: {SOLR_COLLECTION}')
+    logger = logging.getLogger('pipeline')
+    
+    logger.debug(f'Using Solr collection: {SOLR_COLLECTION}')
 
     # Verify solr is running
     try:
         solr_utils.ping_solr()
     except requests.ConnectionError:
-        logging.fatal('Solr is not currently running! Start Solr and try again.')
+        logger.fatal('Solr is not currently running! Start Solr and try again.')
         exit()
 
     if not solr_utils.core_check():
-        logging.fatal(
+        logger.fatal(
             f'Solr core {SOLR_COLLECTION} does not exist. Add a core using "bin/solr create -c {{collection_name}}".')
         exit()
 
 
 def wipe_factors():
-    logging.info('Removing all factors')
+    logger = logging.getLogger('pipeline')
+    
+    logger.info('Removing all factors')
     all_factors = glob(f'{OUTPUT_DIR}/**/transformed_products/**/*_factors')
     for factors_file in all_factors:
         try:
             os.remove(factors_file)
         except:
-            logging.error(f'Error removing {factors_file}')
-        logging.info('Successfully removed all factors')
+            logger.error(f'Error removing {factors_file}')
+        logger.info('Successfully removed all factors')
 
 
 def validate_netrc():
+    logger = logging.getLogger('pipeline')
+    
     try: 
         nrc = netrc.netrc()
         if 'urs.earthdata.nasa.gov' not in nrc.hosts.keys():
-            logging.fatal('Earthdata login required in netrc file.')
+            logger.fatal('Earthdata login required in netrc file.')
             exit()
     except FileNotFoundError:
-        logging.fatal('No netrc found. Please create one and add Earthdata login credentials.')
+        logger.fatal('No netrc found. Please create one and add Earthdata login credentials.')
         exit()
 
 def init_pipeline(args):
-    log_dir = setup_logger(args)
+    logger = setup_logger(args)
     validate_output_dir()
     validate_solr()
     validate_configs()
     validate_netrc()
-
+    
     if args.harvested_entry_validation:
         solr_utils.validate_granules()
 
     if args.wipe_transformations:
-        logging.info('Removing transformations with out of sync version numbers from Solr and disk')
+        logger.info('Removing transformations with out of sync version numbers from Solr and disk')
         solr_utils.delete_mismatch_transformations()
         pass
 
@@ -92,17 +98,17 @@ def init_pipeline(args):
             grids_not_in_solr = grids_to_solr.main(grids_to_use)
             if grids_not_in_solr:
                 for name in grids_not_in_solr:
-                    logging.exception(
+                    logger.exception(
                         f'Grid "{name}" not in Solr. Ensure it\'s file name is present in grids_config.yaml and run pipeline with the --grids_to_solr argument')
                 exit()
-            logging.info('Successfully updated grids on Solr.')
+            logger.info('Successfully updated grids on Solr.')
         except Exception as e:
-            logging.exception(e)
+            logger.exception(e)
 
     if args.wipe_factors:
         wipe_factors()
 
     user_cpus = args.multiprocesses
-    logging.debug(f'Using {user_cpus} processes for multiprocess transformations')
+    logger.debug(f'Using {user_cpus} processes for multiprocess transformations')
 
-    return grids_to_use, user_cpus, log_dir
+    return grids_to_use, user_cpus

--- a/ecco_pipeline/utils/init_pipeline.py
+++ b/ecco_pipeline/utils/init_pipeline.py
@@ -8,13 +8,13 @@ from utils import log_config, solr_utils, grids_to_solr
 from utils.config_validator import validate_configs
 
 try:
-    from conf.global_settings import OUTPUT_DIR, SOLR_COLLECTION, GRIDS
     import conf.global_settings as global_settings
+    from conf.global_settings import OUTPUT_DIR, SOLR_COLLECTION, GRIDS
 except ImportError:
     raise ImportError('Missing global_settings.py file. See ecco_pipeline/conf/global_settings.py.example for more info.')
 
 def setup_logger(args):
-    filename = log_config.configure_logging(True, args.log_level, args.wipe_logs)
+    filename = log_config.root_logging(args.log_level)
 
     # Set package logging level to WARNING
     logging.getLogger("requests").setLevel(logging.WARNING)
@@ -67,7 +67,7 @@ def validate_netrc():
         exit()
 
 def init_pipeline(args):
-    log_filename = setup_logger(args)
+    log_dir = setup_logger(args)
     validate_output_dir()
     validate_solr()
     validate_configs()
@@ -105,4 +105,4 @@ def init_pipeline(args):
     user_cpus = args.multiprocesses
     logging.debug(f'Using {user_cpus} processes for multiprocess transformations')
 
-    return grids_to_use, user_cpus, log_filename
+    return grids_to_use, user_cpus, log_dir

--- a/ecco_pipeline/utils/log_config.py
+++ b/ecco_pipeline/utils/log_config.py
@@ -1,36 +1,22 @@
 import logging
-from logging import FileHandler
 import os
 from datetime import datetime
 
-def root_logging(level: str = 'INFO'):
-    log_directory = os.path.join('logs', datetime.now().strftime("%Y%m%dT%H%M%S"))
-    os.makedirs(log_directory, exist_ok=True)
+timestamp = datetime.now().strftime('%Y%m%dT%H%M%S')
     
-    logfile_path = os.path.join(log_directory, 'pipeline.log')
-    
-    logging.basicConfig(
-        level=get_log_level(level),
-        format='[%(levelname)s] %(asctime)s (%(process)d) - %(message)s',
-        handlers=[
-            FileHandler(logfile_path),
-            logging.StreamHandler(),
-        ]
-    )
-    return log_directory
-
-def mp_logging(pid: str, log_subdir, level: str = 'INFO'):    
-    os.makedirs(log_subdir, exist_ok=True)
-    
-    logfile_path = os.path.join(log_subdir, f'{pid}.log')
-    
-    logger = logging.getLogger(pid)
-    if logger.hasHandlers():
+def mp_logging(log_name: str, level: str = 'INFO', log_dir = 'logs/') -> logging.Logger:       
+    logger = logging.getLogger(log_name)
+    if logger.handlers:
         return logger
     
-    logger.setLevel(get_log_level(level))
+    if log_name == 'pipeline':
+        log_dir = f'logs/{timestamp}'
     
-    formatter = logging.Formatter('[%(levelname)s] %(asctime)s (%(process)d) - %(message)s')
+    os.makedirs(log_dir, exist_ok=True)
+    logfile_path = os.path.join(log_dir, f'{log_name}.log')
+        
+    logger.setLevel(level)
+    formatter = logging.Formatter('[%(levelname)s] %(asctime)s (%(name)s) - %(message)s')
     
     file_handler = logging.FileHandler(logfile_path)        
     file_handler.setFormatter(formatter)
@@ -40,19 +26,3 @@ def mp_logging(pid: str, log_subdir, level: str = 'INFO'):
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
     return logger
-    
-
-def get_log_level(level) -> int:
-    """
-    Defaults to logging.INFO
-    :return:
-    """
-
-    value_map = {
-        'INFO': logging.INFO,
-        'DEBUG': logging.DEBUG,
-        'WARNING': logging.WARNING,
-        'WARN': logging.WARNING,
-    }
-
-    return value_map.get(level, logging.INFO)

--- a/ecco_pipeline/utils/solr_utils.py
+++ b/ecco_pipeline/utils/solr_utils.py
@@ -6,13 +6,12 @@ from pathlib import Path
 
 import requests
 import yaml
-from utils import log_config
 from conf.global_settings import SOLR_COLLECTION, SOLR_HOST
 
 # THIS DOESN"T WORK YET - pipeline logger isn't setup yet
 # log_level = logging.getLevelName(logging.getLogger('pipeline').level)
 # logger = log_config.mp_logging('solr', log_level)
-logger = logging.getLogger('solr')
+# logger = logging.getLogger('solr')
 
 def solr_query(fq, fl=''):
     query_params = {'q': '*:*',
@@ -26,14 +25,14 @@ def solr_query(fq, fl=''):
     except:
         time.sleep(5)
         response = requests.get(url, params=query_params, headers={'Connection': 'close'})
-    logger.debug(f'Querying solr: {response.url}')
+    # logger.debug(f'Querying solr: {response.url}')
     return response.json()['response']['docs']
 
 
 def solr_update(update_body, r=False):
     url = f'{SOLR_HOST}{SOLR_COLLECTION}/update?commit=true'
     response = requests.post(url, json=update_body)
-    logger.debug(f'Updating solr: {response.url}')
+    # logger.debug(f'Updating solr: {response.url}')
     
     if r:
         return response
@@ -72,9 +71,10 @@ def validate_granules():
 
     if docs_to_remove:
         solr_update({'delete': docs_to_remove})
-        logger.info(f'Succesfully removed {len(docs_to_remove)} granules from Solr')
+        # logger.info(f'Succesfully removed {len(docs_to_remove)} granules from Solr')
     else:
-        logger.info('All harvested docs are valid')
+        pass
+        # logger.info('All harvested docs are valid')
 
 
 def clean_solr(config):
@@ -102,7 +102,7 @@ def clean_solr(config):
     else:
         dataset_metadata = dataset_metadata[0]
 
-    logger.info(f'Removing Solr documents related to dates outside of configuration {config_start} to {config_end}')
+    # logger.info(f'Removing Solr documents related to dates outside of configuration {config_start} to {config_end}')
 
     # Remove entries earlier than config start date
     fq = f'dataset_s:{dataset_name} AND date_s:[* TO {config_start}}}'

--- a/ecco_pipeline/utils/solr_utils.py
+++ b/ecco_pipeline/utils/solr_utils.py
@@ -1,5 +1,4 @@
 import logging
-from multiprocessing import current_process
 import os
 import time
 from datetime import datetime
@@ -7,10 +6,13 @@ from pathlib import Path
 
 import requests
 import yaml
+from utils import log_config
 from conf.global_settings import SOLR_COLLECTION, SOLR_HOST
 
-logger = logging.getLogger(str(current_process().pid))
-
+# THIS DOESN"T WORK YET - pipeline logger isn't setup yet
+# log_level = logging.getLevelName(logging.getLogger('pipeline').level)
+# logger = log_config.mp_logging('solr', log_level)
+logger = logging.getLogger('solr')
 
 def solr_query(fq, fl=''):
     query_params = {'q': '*:*',

--- a/ecco_pipeline/utils/solr_utils.py
+++ b/ecco_pipeline/utils/solr_utils.py
@@ -1,4 +1,5 @@
 import logging
+from multiprocessing import current_process
 import os
 import time
 from datetime import datetime
@@ -7,6 +8,8 @@ from pathlib import Path
 import requests
 import yaml
 from conf.global_settings import SOLR_COLLECTION, SOLR_HOST
+
+logger = logging.getLogger(str(current_process().pid))
 
 
 def solr_query(fq, fl=''):
@@ -21,14 +24,14 @@ def solr_query(fq, fl=''):
     except:
         time.sleep(5)
         response = requests.get(url, params=query_params, headers={'Connection': 'close'})
-    logging.debug(f'Querying solr: {response.url}')
+    logger.debug(f'Querying solr: {response.url}')
     return response.json()['response']['docs']
 
 
 def solr_update(update_body, r=False):
     url = f'{SOLR_HOST}{SOLR_COLLECTION}/update?commit=true'
     response = requests.post(url, json=update_body)
-    logging.debug(f'Updating solr: {response.url}')
+    logger.debug(f'Updating solr: {response.url}')
     
     if r:
         return response
@@ -67,9 +70,9 @@ def validate_granules():
 
     if docs_to_remove:
         solr_update({'delete': docs_to_remove})
-        logging.info(f'Succesfully removed {len(docs_to_remove)} granules from Solr')
+        logger.info(f'Succesfully removed {len(docs_to_remove)} granules from Solr')
     else:
-        logging.info('All harvested docs are valid')
+        logger.info('All harvested docs are valid')
 
 
 def clean_solr(config):
@@ -97,7 +100,7 @@ def clean_solr(config):
     else:
         dataset_metadata = dataset_metadata[0]
 
-    logging.info(f'Removing Solr documents related to dates outside of configuration {config_start} to {config_end}')
+    logger.info(f'Removing Solr documents related to dates outside of configuration {config_start} to {config_end}')
 
     # Remove entries earlier than config start date
     fq = f'dataset_s:{dataset_name} AND date_s:[* TO {config_start}}}'


### PR DESCRIPTION
Overhauled how logging works in order to better support multiprocessing in transformation and aggregation. Logs now take the following structure, where timestamp is determined at execution of `run_pipeline.py`:
```
/logs
   /{timestamp}
      pipeline.log
      /tx_{dataset_name}
         {pid}.log
         ...
      /ag_{dataset_name}
         {pid}.log
         ...
```

This PR also includes an improvement to how transformation jobs were determined, greatly reducing the overhead from many unnecessary calls to Solr.

It also includes a new `catds` http harvester which replaces the `ifremer` ftp harvester. This greatly reduces harvesting speed. 