### PR TITLE
Improved handling of loss of Solr data

### DIFF
--- a/ecco_pipeline/aggregations/aggregation_factory.py
+++ b/ecco_pipeline/aggregations/aggregation_factory.py
@@ -1,8 +1,10 @@
 import logging
 import os
+from datetime import datetime
 from multiprocessing import Pool, cpu_count, current_process
 from typing import Iterable
 
+import xarray as xr
 from aggregations.aggregation import Aggregation
 import baseclasses
 from conf.global_settings import OUTPUT_DIR
@@ -230,6 +232,8 @@ class AgJobFactory(baseclasses.Dataset):
                         year_tx_docs = [t for t in transformation_docs if t["date_s"][:4] == year]
                         if self.need_to_aggregate(grid_name, field, year, year_tx_docs):
                             years_to_aggregate.append(year)
+                        else:
+                            self.reconstruct_agg_solr_doc(grid_name, field, year)
                 all_jobs.extend(
                     [
                         Aggregation(self.config, grid, year, field)
@@ -272,3 +276,70 @@ class AgJobFactory(baseclasses.Dataset):
                 return True
 
         return False
+
+    def reconstruct_agg_solr_doc(self, grid_name: str, field, year: str) -> None:
+        """
+        Creates a Solr aggregation doc from existing output files when the doc is
+        missing but processing was determined to be unnecessary.  Mirrors the fields
+        written by Aggregation.aggregate().
+        """
+        data_time_scale = self.data_time_scale
+        shortest_filename = f"{self.ds_name}_{grid_name}_{data_time_scale.upper()}_{field.name}_{year}"
+        monthly_filename = f"{self.ds_name}_{grid_name}_MONTHLY_{field.name}_{year}"
+        output_path = os.path.join(
+            OUTPUT_DIR,
+            self.ds_name,
+            "transformed_products",
+            grid_name,
+            "aggregated",
+            field.name,
+        )
+
+        netcdf_path = os.path.join(output_path, "netCDF", f"{shortest_filename}.nc")
+
+        agg_time = datetime.utcfromtimestamp(
+            os.path.getmtime(netcdf_path)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        doc = {
+            "type_s": "aggregation",
+            "dataset_s": self.ds_name,
+            "year_s": year,
+            "grid_name_s": grid_name,
+            "field_s": field.name,
+            "aggregation_time_dt": agg_time,
+            "aggregation_success_b": True,
+            "aggregation_version_s": str(self.a_version),
+        }
+
+        if data_time_scale == "daily":
+            daily_bin = os.path.join(output_path, "bin", shortest_filename)
+            doc["aggregated_daily_bin_path_s"] = daily_bin if os.path.exists(daily_bin) else ""
+            doc["aggregated_daily_netCDF_path_s"] = netcdf_path
+
+        with xr.open_dataset(netcdf_path) as ds:
+            daily_uuid = ds.attrs.get("uuid")
+        if daily_uuid:
+            doc["daily_aggregated_uuid_s"] = daily_uuid
+
+        do_monthly = self.config.get("do_monthly_aggregation", False)
+        if data_time_scale == "monthly" or do_monthly:
+            monthly_netcdf = os.path.join(output_path, "netCDF", f"{monthly_filename}.nc")
+            monthly_bin = os.path.join(output_path, "bin", monthly_filename)
+            doc["aggregated_monthly_netCDF_path_s"] = monthly_netcdf if os.path.exists(monthly_netcdf) else ""
+            doc["aggregated_monthly_bin_path_s"] = monthly_bin if os.path.exists(monthly_bin) else ""
+            if os.path.exists(monthly_netcdf):
+                with xr.open_dataset(monthly_netcdf) as ds:
+                    monthly_uuid = ds.attrs.get("uuid")
+                if monthly_uuid:
+                    doc["monthly_aggregated_uuid_s"] = monthly_uuid
+
+        r = solr_utils.solr_update([doc], r=True)
+        if r.status_code == 200:
+            logger.debug(
+                f"Reconstructed missing Solr aggregation doc for {self.ds_name} {grid_name} {field.name} {year}"
+            )
+        else:
+            logger.warning(
+                f"Failed to reconstruct Solr aggregation doc for {self.ds_name} {grid_name} {field.name} {year}"
+            )

--- a/ecco_pipeline/aggregations/aggregation_factory.py
+++ b/ecco_pipeline/aggregations/aggregation_factory.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 from aggregations.aggregation import Aggregation
 import baseclasses
+from conf.global_settings import OUTPUT_DIR
 from utils.pipeline_utils import log_config, solr_utils
 
 logger = logging.getLogger("pipeline")
@@ -226,7 +227,9 @@ class AgJobFactory(baseclasses.Dataset):
                                 years_to_aggregate.append(year)
                                 break
                     else:
-                        years_to_aggregate.append(year)
+                        year_tx_docs = [t for t in transformation_docs if t["date_s"][:4] == year]
+                        if self.need_to_aggregate(grid_name, field, year, year_tx_docs):
+                            years_to_aggregate.append(year)
                 all_jobs.extend(
                     [
                         Aggregation(self.config, grid, year, field)
@@ -234,3 +237,38 @@ class AgJobFactory(baseclasses.Dataset):
                     ]
                 )
         return all_jobs
+
+    def need_to_aggregate(self, grid_name: str, field, year: str, year_tx_docs: list) -> bool:
+        """
+        Filesystem fallback used when no Solr aggregation doc exists for a
+        grid/field/year combination.  Skip re-aggregation if the output netCDF
+        file already exists and is newer than every transformation file that
+        feeds into it.
+        """
+        shortest_filename = f"{self.ds_name}_{grid_name}_{self.data_time_scale.upper()}_{field.name}_{year}"
+        output_path = os.path.join(
+            OUTPUT_DIR,
+            self.ds_name,
+            "transformed_products",
+            grid_name,
+            "aggregated",
+            field.name,
+            "netCDF",
+            f"{shortest_filename}.nc",
+        )
+
+        if not os.path.exists(output_path):
+            return True
+
+        if not year_tx_docs:
+            return True
+
+        agg_mtime = os.path.getmtime(output_path)
+        for tx in year_tx_docs:
+            tx_path = tx.get("transformation_file_path_s")
+            if not tx_path or not os.path.exists(tx_path):
+                return True
+            if os.path.getmtime(tx_path) > agg_mtime:
+                return True
+
+        return False

--- a/ecco_pipeline/transformations/transformation_factory.py
+++ b/ecco_pipeline/transformations/transformation_factory.py
@@ -6,6 +6,7 @@ from typing import Iterable
 
 import xarray as xr
 import baseclasses
+from conf.global_settings import OUTPUT_DIR
 from transformations.grid_transformation import Transformation, transform
 from utils.pipeline_utils import log_config, solr_utils
 
@@ -222,6 +223,8 @@ class TxJobFactory(baseclasses.Dataset):
                         if tx["field_s"] == field.name and tx["grid_name_s"] == grid:
                             update = self.need_to_update(granule, tx)
                             break
+                    else:
+                        update = self.need_to_transform(granule, grid, field)
                     if update:
                         fields_for_grid.append(field)
                 if fields_for_grid:
@@ -245,3 +248,27 @@ class TxJobFactory(baseclasses.Dataset):
         ):
             return False
         return True
+
+    def need_to_transform(self, granule: dict, grid_name: str, field) -> bool:
+        """
+        Filesystem fallback used when no Solr transformation doc exists for a
+        granule/grid/field combination.  Mirrors the harvester's need_to_download()
+        logic: skip reprocessing if the transformed output file already exists and
+        is newer than the source granule file.
+        """
+        stem = os.path.splitext(granule["filename_s"])[0]
+        output_path = os.path.join(
+            OUTPUT_DIR,
+            self.ds_name,
+            "transformed_products",
+            grid_name,
+            "transformed",
+            field.name,
+            f"{grid_name}_{field.name}_{stem}.nc",
+        )
+        if not os.path.exists(output_path):
+            return True
+        source_path = granule.get("pre_transformation_file_path_s")
+        if not source_path or not os.path.exists(source_path):
+            return True
+        return os.path.getmtime(output_path) <= os.path.getmtime(source_path)

--- a/ecco_pipeline/transformations/transformation_factory.py
+++ b/ecco_pipeline/transformations/transformation_factory.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from collections import defaultdict
+from datetime import datetime
 from multiprocessing import Pool, cpu_count, current_process
 from typing import Iterable
 
@@ -8,7 +9,7 @@ import xarray as xr
 import baseclasses
 from conf.global_settings import OUTPUT_DIR
 from transformations.grid_transformation import Transformation, transform
-from utils.pipeline_utils import log_config, solr_utils
+from utils.pipeline_utils import file_utils, log_config, solr_utils
 
 logger = logging.getLogger("pipeline")
 
@@ -225,6 +226,8 @@ class TxJobFactory(baseclasses.Dataset):
                             break
                     else:
                         update = self.need_to_transform(granule, grid, field)
+                        if not update:
+                            self.reconstruct_tx_solr_doc(granule, grid, field)
                     if update:
                         fields_for_grid.append(field)
                 if fields_for_grid:
@@ -272,3 +275,59 @@ class TxJobFactory(baseclasses.Dataset):
         if not source_path or not os.path.exists(source_path):
             return True
         return os.path.getmtime(output_path) <= os.path.getmtime(source_path)
+
+    def reconstruct_tx_solr_doc(self, granule: dict, grid_name: str, field) -> None:
+        """
+        Creates a Solr transformation doc from an existing output file when the
+        doc is missing but processing was determined to be unnecessary.  Mirrors
+        the fields written by prepopulate_solr() + the post-transform update in
+        grid_transformation.transform().
+        """
+        stem = os.path.splitext(granule["filename_s"])[0]
+        output_filename = f"{grid_name}_{field.name}_{stem}.nc"
+        output_path = os.path.join(
+            OUTPUT_DIR,
+            self.ds_name,
+            "transformed_products",
+            grid_name,
+            "transformed",
+            field.name,
+            output_filename,
+        )
+
+        hemi = ""
+        if self.hemi_pattern:
+            if self.hemi_pattern["north"] in granule["filename_s"]:
+                hemi = "nh"
+            elif self.hemi_pattern["south"] in granule["filename_s"]:
+                hemi = "sh"
+
+        completed_dt = datetime.utcfromtimestamp(
+            os.path.getmtime(output_path)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        doc = {
+            "type_s": "transformation",
+            "date_s": granule["date_s"],
+            "dataset_s": self.ds_name,
+            "pre_transformation_file_path_s": granule.get("pre_transformation_file_path_s"),
+            "hemisphere_s": hemi,
+            "origin_checksum_s": granule.get("checksum_s"),
+            "grid_name_s": grid_name,
+            "field_s": field.name,
+            "transformation_in_progress_b": False,
+            "success_b": True,
+            "filename_s": output_filename,
+            "transformation_file_path_s": output_path,
+            "transformation_completed_dt": completed_dt,
+            "transformation_checksum_s": file_utils.md5(output_path),
+            "transformation_version_f": self.t_version,
+        }
+
+        r = solr_utils.solr_update([doc], r=True)
+        if r.status_code == 200:
+            logger.debug(f"Reconstructed missing Solr transformation doc for {output_filename}")
+        else:
+            logger.warning(
+                f"Failed to reconstruct Solr transformation doc for {output_filename}"
+            )

--- a/ecco_pipeline/utils/pipeline_utils/init_pipeline.py
+++ b/ecco_pipeline/utils/pipeline_utils/init_pipeline.py
@@ -47,9 +47,9 @@ def validate_solr():
         logger.fatal("Solr is not currently running! Start Solr and try again.")
         exit()
 
-    if not solr_utils.core_check():
+    if not solr_utils.collection_check():
         logger.fatal(
-            f'Solr core {SOLR_COLLECTION} does not exist. Add a core using "bin/solr create -c {{collection_name}}".'
+            f'Solr collection {SOLR_COLLECTION} does not exist. Add a collection using "bin/solr create -c {{collection_name}}".'
         )
         exit()
 

--- a/ecco_pipeline/utils/pipeline_utils/solr_utils.py
+++ b/ecco_pipeline/utils/pipeline_utils/solr_utils.py
@@ -46,13 +46,13 @@ def ping_solr():
     requests.get(url)
 
 
-def core_check() -> bool:
+def collection_check() -> bool:
     """
-    Check if core has been created on Solr
+    Check if collection exists on Solr
     """
-    url = f"{SOLR_HOST}admin/cores?action=STATUS&core={SOLR_COLLECTION}"
+    url = f"{SOLR_HOST}admin/collections?action=LIST"
     response = requests.get(url).json()
-    if response["status"][SOLR_COLLECTION].keys():
+    if SOLR_COLLECTION in response["collections"]:
         return True
     return False
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@
 name: ecco_pipeline
 channels:
   - conda-forge
-  - default
 dependencies:
   - python=3.10.10
   - pyresample=1.26.1


### PR DESCRIPTION
In the event Solr data is unrecoverable we want to avoid reprocessing data that already exists. Support for this feature already exists in harvesting, but was missing from transformation and aggregation. This PR adds that missing support.

If a file exists locally but with no corresponding Solr doc, upstream files are checked for needed processing by comparing mod times. If processing is not needed, the missing Solr doc is populated. 