### PR TITLE
fix: correct stale grid_file_path variable in grids_to_solr

### DIFF
--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -333,7 +333,7 @@ class Aggregation(Dataset):
                 for date in sorted(missing_dates)
             ]
             missing_dates_ds = xr.concat(empty_records, dim="time")
-            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override", coords="minimal")
+            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time")
         daily_annual_ds = daily_annual_ds.sortby(daily_annual_ds.time)
 
         data_var = list(daily_annual_ds.keys())[0]

--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -333,7 +333,7 @@ class Aggregation(Dataset):
                 for date in sorted(missing_dates)
             ]
             missing_dates_ds = xr.concat(empty_records, dim="time")
-            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time")
+            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override")
         daily_annual_ds = daily_annual_ds.sortby(daily_annual_ds.time)
 
         data_var = list(daily_annual_ds.keys())[0]

--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -333,7 +333,7 @@ class Aggregation(Dataset):
                 for date in sorted(missing_dates)
             ]
             missing_dates_ds = xr.concat(empty_records, dim="time")
-            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override")
+            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override", coords="minimal")
         daily_annual_ds = daily_annual_ds.sortby(daily_annual_ds.time)
 
         data_var = list(daily_annual_ds.keys())[0]

--- a/ecco_pipeline/utils/pipeline_utils/init_pipeline.py
+++ b/ecco_pipeline/utils/pipeline_utils/init_pipeline.py
@@ -156,6 +156,7 @@ def update_solr_grid(grid_name: str, grid_type: str, grid_file_path: str):
                     "id": grid_metadata["id"],
                     "grid_type_s": {"set": grid_type},
                     "grid_name_s": {"set": grid_name},
+                    "grid_path_s": {"set": str(grid_file_path)},
                     "grid_checksum_s": {"set": current_checksum},
                     "date_added_dt": {
                         "set": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -179,17 +180,16 @@ def grids_to_solr(grids_to_use: Iterable[str] = []):
 
     grids = []
     for grid_file_path in grid_files:
-        grid_file_name = os.path.basename(grid_file_path)
         ds = xr.open_dataset(grid_file_path)
         # Assumes grids conform to metadata standard (see documentation)
         grid_name = ds.attrs["name"]
         grid_type = ds.attrs["type"]
-        grids.append((grid_name, grid_type, grid_file_name))
-        logger.debug(f"Loaded {grid_name} {grid_type} {grid_file_name}")
+        grids.append((grid_name, grid_type, grid_file_path))
+        logger.debug(f"Loaded {grid_name} {grid_type} {grid_file_path}")
 
     # Create Solr grid-type document for each missing grid type
-    for grid_name, grid_type, grid_file_name in grids:
-        logger.debug(f"Uploading solr grid {grid_name} {grid_type} {grid_file_name}")
+    for grid_name, grid_type, grid_file_path in grids:
+        logger.debug(f"Uploading solr grid {grid_name} {grid_type} {grid_file_path}")
         update_solr_grid(grid_name, grid_type, grid_file_path)
 
     # Verify grid names supplied exist on Solr

--- a/ecco_pipeline/utils/processing_utils/records.py
+++ b/ecco_pipeline/utils/processing_utils/records.py
@@ -174,10 +174,9 @@ def save_netcdf(data: xr.Dataset, output_filename: str, netcdf_output_dir: str):
 
     coord_encoding = {}
     for coord in data_DS.coords:
+        coord_encoding[coord] = {"_FillValue": None, "dtype": "float32"}
         if coord == "time" or coord == "time_bnds":
             coord_encoding[coord] = {"dtype": "int32"}
-        else:
-            coord_encoding[coord] = {"_FillValue": None}
     coord_encoding["time"] = {"units": "hours since 1980-01-01"}
 
     var_encoding = {}

--- a/ecco_pipeline/utils/processing_utils/records.py
+++ b/ecco_pipeline/utils/processing_utils/records.py
@@ -174,10 +174,10 @@ def save_netcdf(data: xr.Dataset, output_filename: str, netcdf_output_dir: str):
 
     coord_encoding = {}
     for coord in data_DS.coords:
-        coord_encoding[coord] = {"_FillValue": None, "dtype": "float32"}
-
         if coord == "time" or coord == "time_bnds":
             coord_encoding[coord] = {"dtype": "int32"}
+        else:
+            coord_encoding[coord] = {"_FillValue": None}
     coord_encoding["time"] = {"units": "hours since 1980-01-01"}
 
     var_encoding = {}


### PR DESCRIPTION
## Problem                                                                                                                          
                                                                                                                                   
  grids_to_solr iterated over grid files in one loop to build a grids list, then called update_solr_grid in a second loop — but    
  continued to pass grid_file_path, the loop variable from the first loop. After the first loop exits, grid_file_path holds
  whatever the last file in the glob happened to be, so every grid got written to Solr with that same stale path.                  
                                                            
  In practice this meant all grids (ECCO_llc90, ECCO_llc270, TPOSE) ended up with grid_path_s pointing to polar_stereo_n_25km.nc,  
  causing the pipeline to open the wrong model grid file during aggregation. This was a recent change that was only discovered on a fresh pipeline deployment to solr.
                                                                                                                                   
  ## Changes                                                                                                                        

  - grids_to_solr: store the full file path (not just the basename) in the grids list, and use it in the second loop.              
  - update_solr_grid: include grid_path_s in the Solr update body when a checksum mismatch is detected, so the path is corrected
  alongside the checksum rather than left stale.                                                                                   
                                                                                                                                 
  ## Notes                                                                                                                            
                                                                                                                                 
  Existing corrupted Solr grid documents must be patched manually (or by re-running --grids_to_solr after deleting the affected    
  grid docs) — the code fix prevents recurrence but does not self-heal already-written documents. Any transformations performed using the incorrect grid must also be removed.

Bug was discovered as part of #100 