### PR TITLE
perf/fix: parallelize enumeration and downloads across all web-scraped harvesters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+*.egg-info
+
 ecco_pipeline/logs
 
 *.ipynb_checkpoints/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.11
+    hooks:
+      - id: ruff-check
+        types_or: [ python, pyi ]
+        args: [--fix]
+      - id: ruff-format
+        types_or: [ python, pyi ]

--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -333,7 +333,7 @@ class Aggregation(Dataset):
                 for date in sorted(missing_dates)
             ]
             missing_dates_ds = xr.concat(empty_records, dim="time")
-            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override", coords="minimal")
+            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time")
         daily_annual_ds = daily_annual_ds.sortby(daily_annual_ds.time)
 
         data_var = list(daily_annual_ds.keys())[0]

--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -333,7 +333,7 @@ class Aggregation(Dataset):
                 for date in sorted(missing_dates)
             ]
             missing_dates_ds = xr.concat(empty_records, dim="time")
-            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time")
+            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override")
         daily_annual_ds = daily_annual_ds.sortby(daily_annual_ds.time)
 
         data_var = list(daily_annual_ds.keys())[0]

--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -333,7 +333,7 @@ class Aggregation(Dataset):
                 for date in sorted(missing_dates)
             ]
             missing_dates_ds = xr.concat(empty_records, dim="time")
-            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override")
+            daily_annual_ds = xr.concat([daily_annual_ds, missing_dates_ds], dim="time", compat="override", coords="minimal")
         daily_annual_ds = daily_annual_ds.sortby(daily_annual_ds.time)
 
         data_var = list(daily_annual_ds.keys())[0]

--- a/ecco_pipeline/harvesters/catds_harvester.py
+++ b/ecco_pipeline/harvesters/catds_harvester.py
@@ -12,7 +12,7 @@ from utils.pipeline_utils.file_utils import get_date
 
 logger = logging.getLogger("pipeline")
 
-MAX_WORKERS = 10
+MAX_WORKERS = 3
 CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 

--- a/ecco_pipeline/harvesters/catds_harvester.py
+++ b/ecco_pipeline/harvesters/catds_harvester.py
@@ -32,12 +32,14 @@ class CATDS_Harvester(Harvester):
                 continue
             to_process.append((catds_granule, filename, dt))
 
+        for _, _, dt in to_process:
+            os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
+
         lock = threading.Lock()
 
         def process_granule(catds_granule: CATDSGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
-            os.makedirs(os.path.dirname(local_fp), exist_ok=True)
 
             if not self.check_update(filename, catds_granule.mod_time):
                 return []
@@ -72,7 +74,7 @@ class CATDS_Harvester(Harvester):
         logger.info(f"Downloading {self.ds_name} complete")
 
     def dl_file(self, src: str, dst: str):
-        with requests.get(src, stream=True) as r:
+        with requests.get(src, stream=True, timeout=120) as r:
             r.raise_for_status()
             with open(dst, "wb") as f:
                 for chunk in r.iter_content(chunk_size=CHUNK_SIZE):

--- a/ecco_pipeline/harvesters/catds_harvester.py
+++ b/ecco_pipeline/harvesters/catds_harvester.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Iterable
 
@@ -10,6 +12,9 @@ from utils.pipeline_utils.file_utils import get_date
 
 logger = logging.getLogger("pipeline")
 
+MAX_WORKERS = 10
+CHUNK_SIZE = 1024 * 1024  # 1 MB
+
 
 class CATDS_Harvester(Harvester):
     def __init__(self, config: dict):
@@ -17,47 +22,61 @@ class CATDS_Harvester(Harvester):
         self.catds_granules: Iterable[CATDSGranule] = search_catds(self)
 
     def fetch(self):
+        # Pre-filter granules to only those within the date range
+        to_process = []
         for catds_granule in self.catds_granules:
             filename = catds_granule.url.split("/")[-1]
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
             dt = datetime.strptime(date, self.filename_date_fmt)
-            if not ((self.start <= dt) and (self.end >= dt)):
+            if not (self.start <= dt <= self.end):
                 continue
+            to_process.append((catds_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_granule(catds_granule: CATDSGranule, filename: str, dt: datetime):
             year = str(dt.year)
-
             local_fp = os.path.join(self.target_dir, year, filename)
             os.makedirs(os.path.dirname(local_fp), exist_ok=True)
 
-            if self.check_update(filename, catds_granule.mod_time):
-                success = True
-                granule = Granule(
-                    self.ds_name,
-                    local_fp,
-                    dt,
-                    catds_granule.mod_time,
-                    catds_granule.url,
-                )
+            if not self.check_update(filename, catds_granule.mod_time):
+                return []
 
-                if self.need_to_download(granule):
-                    logger.info(f"Downloading {filename} to {local_fp}")
-                    try:
-                        self.dl_file(catds_granule.url, local_fp)
-                    except Exception:
-                        success = False
-                else:
-                    logger.debug(f"{filename} already downloaded and up to date")
+            success = True
+            granule = Granule(
+                self.ds_name, local_fp, dt, catds_granule.mod_time, catds_granule.url
+            )
 
-                granule.update_item(self.solr_docs, success)
-                granule.update_descendant(self.descendant_docs, success)
-                self.updated_solr_docs.extend(granule.get_solr_docs())
+            if self.need_to_download(granule):
+                logger.info(f"Downloading {filename} to {local_fp}")
+                try:
+                    self.dl_file(catds_granule.url, local_fp)
+                except Exception:
+                    success = False
+            else:
+                logger.debug(f"{filename} already downloaded and up to date")
+
+            granule.update_item(self.solr_docs, success)
+            granule.update_descendant(self.descendant_docs, success)
+            return granule.get_solr_docs()
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(process_granule, *args) for args in to_process
+            ]
+            for future in as_completed(futures):
+                docs = future.result()
+                with lock:
+                    self.updated_solr_docs.extend(docs)
+
         logger.info(f"Downloading {self.ds_name} complete")
 
     def dl_file(self, src: str, dst: str):
-        r = requests.get(src)
-        r.raise_for_status()
-        open(dst, "wb").write(r.content)
+        with requests.get(src, stream=True) as r:
+            r.raise_for_status()
+            with open(dst, "wb") as f:
+                for chunk in r.iter_content(chunk_size=CHUNK_SIZE):
+                    f.write(chunk)
 
 
 def harvester(config: dict) -> str:

--- a/ecco_pipeline/harvesters/cmr_harvester.py
+++ b/ecco_pipeline/harvesters/cmr_harvester.py
@@ -129,75 +129,81 @@ class CMR_Harvester(Harvester):
                 )
 
             solr_docs = []
-            if dl_success:
-                base_ds = xr.open_dataset(local_fp, decode_times=True)
-                base_ds = base_ds[["grid_x", "grid_y", "crs"]]
+            if not dl_success:
+                return solr_docs
 
-                for i in range(1, 32):
-                    if not self.check_update(filename, cmr_granule.mod_time):
-                        continue
+            # Determine which days are missing from Solr before opening any files
+            days_needing_update = []
+            for i in range(1, 32):
+                try:
+                    datetime(dt.year, dt.month, i)
+                except ValueError:
+                    continue
+                day_number = str(i).zfill(2)
+                daily_filename = (
+                    filename[:9]
+                    + year
+                    + str(month).zfill(2)
+                    + day_number
+                    + filename[-10:-3]
+                    + ".nc"
+                )
+                if self.check_update(daily_filename, cmr_granule.mod_time):
+                    days_needing_update.append((i, day_number, daily_filename))
 
-                    success = True
-                    day_number = str(i).zfill(2)
+            if not days_needing_update:
+                return solr_docs
 
-                    try:
-                        datetime(dt.year, dt.month, i)
-                    except Exception:
-                        continue
+            base_ds = xr.open_dataset(local_fp, decode_times=True)
+            base_ds = base_ds[["grid_x", "grid_y", "crs"]]
 
-                    daily_filename = (
-                        filename[:9]
-                        + year
-                        + str(month).zfill(2)
-                        + day_number
-                        + filename[-10:-3]
-                        + ".nc"
-                    )
-                    daily_local_fp = os.path.join(self.target_dir, year, daily_filename)
+            for i, day_number, daily_filename in days_needing_update:
+                daily_local_fp = os.path.join(self.target_dir, year, daily_filename)
 
-                    try:
-                        var_ds = xr.open_dataset(local_fp, group=f"daily/day{day_number}")
-                    except Exception:
-                        continue
+                try:
+                    var_ds = xr.open_dataset(local_fp, group=f"daily/day{day_number}")
+                except Exception:
+                    continue
 
-                    try:
-                        mid_date = (
-                            var_ds.delta_time_beg.values[0]
-                            + (
-                                (
-                                    var_ds.delta_time_end.values[0]
-                                    - var_ds.delta_time_beg.values[0]
-                                )
-                                / 2
+                success = True
+                try:
+                    mid_date = (
+                        var_ds.delta_time_beg.values[0]
+                        + (
+                            (
+                                var_ds.delta_time_end.values[0]
+                                - var_ds.delta_time_beg.values[0]
                             )
-                        ).astype(str)[:10]
-                        time_val = np.datetime64(mid_date).astype("datetime64[ns]")
-                        time_var_ds = var_ds.expand_dims({"time": [time_val]})
-                        time_var_ds = time_var_ds[[field.name for field in self.fields]]
-                        merged_ds = xr.merge([base_ds, time_var_ds])
-                        merged_ds.to_netcdf(daily_local_fp)
-                        merged_ds.close()
-                    finally:
-                        var_ds.close()
-
-                    try:
-                        daily_dt = datetime(int(year), int(month), i)
-                        daily_granule = Granule(
-                            self.ds_name,
-                            daily_local_fp,
-                            daily_dt,
-                            cmr_granule.mod_time,
-                            cmr_granule.url,
+                            / 2
                         )
-                        daily_granule.update_item(self.solr_docs, success)
-                        daily_granule.update_descendant(self.descendant_docs, success)
-                        solr_docs.extend(daily_granule.get_solr_docs())
-                    except Exception:
-                        logger.debug(
-                            f"{year}-{str(month).zfill(2)}-{day_number} unable to be sliced. Daily data likely missing in monthly file."
-                        )
+                    ).astype(str)[:10]
+                    time_val = np.datetime64(mid_date).astype("datetime64[ns]")
+                    time_var_ds = var_ds.expand_dims({"time": [time_val]})
+                    time_var_ds = time_var_ds[[field.name for field in self.fields]]
+                    merged_ds = xr.merge([base_ds, time_var_ds])
+                    merged_ds.to_netcdf(daily_local_fp)
+                    merged_ds.close()
+                finally:
+                    var_ds.close()
 
-                base_ds.close()
+                try:
+                    daily_dt = datetime(int(year), int(month), i)
+                    daily_granule = Granule(
+                        self.ds_name,
+                        daily_local_fp,
+                        daily_dt,
+                        cmr_granule.mod_time,
+                        cmr_granule.url,
+                    )
+                    daily_granule.update_item(self.solr_docs, success)
+                    daily_granule.update_descendant(self.descendant_docs, success)
+                    solr_docs.extend(daily_granule.get_solr_docs())
+                except Exception:
+                    logger.debug(
+                        f"{year}-{str(month).zfill(2)}-{day_number} unable to be sliced. Daily data likely missing in monthly file."
+                    )
+
+            base_ds.close()
             return solr_docs
 
         # xarray/netCDF4 operations are CPU-bound — 1 worker avoids core saturation

--- a/ecco_pipeline/harvesters/cmr_harvester.py
+++ b/ecco_pipeline/harvesters/cmr_harvester.py
@@ -29,7 +29,7 @@ class CMR_Harvester(Harvester):
     def dl_file(self, src: str, dst: str):
         for attempt in range(2):
             try:
-                with requests.get(src, stream=True) as r:
+                with requests.get(src, stream=True, timeout=120) as r:
                     r.raise_for_status()
                     with open(dst, "wb") as f:
                         for chunk in r.iter_content(chunk_size=CHUNK_SIZE):
@@ -53,12 +53,14 @@ class CMR_Harvester(Harvester):
                 continue
             to_process.append((cmr_granule, filename, dt))
 
+        for _, _, dt in to_process:
+            os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
+
         lock = threading.Lock()
 
         def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
-            os.makedirs(os.path.join(self.target_dir, year), exist_ok=True)
 
             if not self.check_update(filename, cmr_granule.mod_time):
                 return []

--- a/ecco_pipeline/harvesters/cmr_harvester.py
+++ b/ecco_pipeline/harvesters/cmr_harvester.py
@@ -1,6 +1,8 @@
 import calendar
 import logging
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 import time
 from typing import Iterable
@@ -15,75 +17,95 @@ from utils.processing_utils.records import TimeBound
 
 logger = logging.getLogger("pipeline")
 
+MAX_WORKERS = 10
+CHUNK_SIZE = 1024 * 1024  # 1 MB
+
 
 class CMR_Harvester(Harvester):
     def __init__(self, config: dict):
         super().__init__(config)
         self.cmr_granules: Iterable[CMRGranule] = CMRQuery(self).query()
 
+    def dl_file(self, src: str, dst: str):
+        for attempt in range(2):
+            try:
+                with requests.get(src, stream=True) as r:
+                    r.raise_for_status()
+                    with open(dst, "wb") as f:
+                        for chunk in r.iter_content(chunk_size=CHUNK_SIZE):
+                            f.write(chunk)
+                return
+            except Exception:
+                if attempt == 0:
+                    time.sleep(5)
+                else:
+                    raise
+
     def fetch(self):
+        to_process = []
         for cmr_granule in self.cmr_granules:
             filename = cmr_granule.url.split("/")[-1]
             if "NRT" in filename:
                 continue
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
             dt = datetime.strptime(date, self.filename_date_fmt)
-            if not (self.start <= dt) and (self.end >= dt):
+            if not ((self.start <= dt) and (self.end >= dt)):
                 continue
+            to_process.append((cmr_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
-
             local_fp = os.path.join(self.target_dir, year, filename)
             os.makedirs(os.path.join(self.target_dir, year), exist_ok=True)
 
-            if self.check_update(filename, cmr_granule.mod_time):
-                success = True
-                granule = Granule(
-                    self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
-                )
+            if not self.check_update(filename, cmr_granule.mod_time):
+                return []
 
-                if self.need_to_download(granule):
-                    logger.info(f"Downloading {filename} to {local_fp}")
-                    try:
-                        self.dl_file(cmr_granule.url, local_fp)
-                    except Exception:
-                        success = False
-                else:
-                    logger.debug(f"{filename} already downloaded and up to date")
+            success = True
+            granule = Granule(
+                self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
+            )
 
-                granule.update_item(self.solr_docs, success)
-                granule.update_descendant(self.descendant_docs, success)
-                self.updated_solr_docs.extend(granule.get_solr_docs())
+            if self.need_to_download(granule):
+                logger.info(f"Downloading {filename} to {local_fp}")
+                try:
+                    self.dl_file(cmr_granule.url, local_fp)
+                except Exception:
+                    success = False
+            else:
+                logger.debug(f"{filename} already downloaded and up to date")
+
+            granule.update_item(self.solr_docs, success)
+            granule.update_descendant(self.descendant_docs, success)
+            return granule.get_solr_docs()
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [executor.submit(process_granule, *args) for args in to_process]
+            for future in as_completed(futures):
+                with lock:
+                    self.updated_solr_docs.extend(future.result())
+
         logger.info(f"Downloading {self.ds_name} complete")
 
-    def dl_file(self, src: str, dst: str):
-        try:
-            r = requests.get(src)
-            r.raise_for_status()
-            with open(dst, "wb") as f:
-                f.write(r.content)
-        except Exception:
-            time.sleep(5)
-            r = requests.get(src)
-            r.raise_for_status()
-            with open(dst, "wb") as f:
-                f.write(r.content)
-
     def fetch_atl_daily(self):
+        to_process = []
         for cmr_granule in self.cmr_granules:
             filename = cmr_granule.url.split("/")[-1]
             if "NRT" in filename:
                 continue
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
             dt = datetime.strptime(date, self.filename_date_fmt)
-            if not (self.start <= dt) and (self.end >= dt):
+            if not ((self.start <= dt) and (self.end >= dt)):
                 continue
+            to_process.append((cmr_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_monthly_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
             month = str(dt.month)
-
             local_fp = os.path.join(self.target_dir, year, filename)
             os.makedirs(os.path.join(self.target_dir, year), exist_ok=True)
 
@@ -92,12 +114,10 @@ class CMR_Harvester(Harvester):
             )
 
             dl_success = True
-
             if self.need_to_download(native_granule):
                 logger.info(f"Downloading {filename} to {local_fp}")
                 try:
                     self.dl_file(cmr_granule.url, local_fp)
-                    dl_success = True
                 except Exception as e:
                     logger.warning(e)
                     dl_success = False
@@ -106,11 +126,11 @@ class CMR_Harvester(Harvester):
                     f"{year}-{str(month).zfill(2)} monthly file up to date. Slicing to ensure entries in Solr..."
                 )
 
+            solr_docs = []
             if dl_success:
                 base_ds = xr.open_dataset(local_fp, decode_times=True)
                 base_ds = base_ds[["grid_x", "grid_y", "crs"]]
 
-                # Pull out daily slices from monthly granule
                 for i in range(1, 32):
                     if not self.check_update(filename, cmr_granule.mod_time):
                         continue
@@ -118,12 +138,11 @@ class CMR_Harvester(Harvester):
                     success = True
                     day_number = str(i).zfill(2)
 
-                    # Try to make a datetime object
                     try:
                         datetime(dt.year, dt.month, i)
                     except Exception:
-                        # Day number is not valid for this month
                         continue
+
                     daily_filename = (
                         filename[:9]
                         + year
@@ -135,12 +154,10 @@ class CMR_Harvester(Harvester):
                     daily_local_fp = os.path.join(self.target_dir, year, daily_filename)
 
                     try:
-                        var_ds = xr.open_dataset(
-                            local_fp, group=f"daily/day{day_number}"
-                        )
+                        var_ds = xr.open_dataset(local_fp, group=f"daily/day{day_number}")
                     except Exception:
-                        # Day number is not valid for this month
                         continue
+
                     mid_date = (
                         var_ds.delta_time_beg.values[0]
                         + (
@@ -151,8 +168,8 @@ class CMR_Harvester(Harvester):
                             / 2
                         )
                     ).astype(str)[:10]
-                    date = np.datetime64(mid_date).astype("datetime64[ns]")
-                    time_var_ds = var_ds.expand_dims({"time": [date]})
+                    time_val = np.datetime64(mid_date).astype("datetime64[ns]")
+                    time_var_ds = var_ds.expand_dims({"time": [time_val]})
                     time_var_ds = time_var_ds[[field.name for field in self.fields]]
                     merged_ds = xr.merge([base_ds, time_var_ds])
                     merged_ds.to_netcdf(daily_local_fp)
@@ -168,31 +185,44 @@ class CMR_Harvester(Harvester):
                         )
                         daily_granule.update_item(self.solr_docs, success)
                         daily_granule.update_descendant(self.descendant_docs, success)
-                        self.updated_solr_docs.extend(daily_granule.get_solr_docs())
+                        solr_docs.extend(daily_granule.get_solr_docs())
                     except Exception:
                         logger.debug(
                             f"{year}-{str(month).zfill(2)}-{day_number} unable to be sliced. Daily data likely missing in monthly file."
                         )
+            return solr_docs
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(process_monthly_granule, *args) for args in to_process
+            ]
+            for future in as_completed(futures):
+                with lock:
+                    self.updated_solr_docs.extend(future.result())
+
         logger.info(f"Downloading {self.ds_name} complete")
 
     def fetch_tellus_grac_grfo(self):
+        to_process = []
         for cmr_granule in self.cmr_granules:
             filename = cmr_granule.url.split("/")[-1]
             if "NRT" in filename:
                 continue
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
             dt = datetime.strptime(date, self.filename_date_fmt)
-            if not (self.start <= dt) and (self.end >= dt):
+            if not ((self.start <= dt) and (self.end >= dt)):
                 continue
+            to_process.append((cmr_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             local_fp = os.path.join(self.target_dir, filename)
-            os.makedirs(os.path.join(self.target_dir), exist_ok=True)
+            os.makedirs(self.target_dir, exist_ok=True)
 
             if (
                 not os.path.exists(local_fp)
-                or datetime.fromtimestamp(os.path.getmtime(local_fp))
-                < cmr_granule.mod_time
+                or datetime.fromtimestamp(os.path.getmtime(local_fp)) < cmr_granule.mod_time
             ):
                 logger.info(f"Downloading {filename} to {local_fp}")
                 self.dl_file(cmr_granule.url, local_fp)
@@ -203,36 +233,26 @@ class CMR_Harvester(Harvester):
 
             ds = xr.open_dataset(local_fp, decode_times=True)
 
-            # Extract time coverage from file metadata
             time_start = np.datetime64(ds.attrs["time_coverage_start"][:-1]).astype(
                 "datetime64[M]"
             )
             time_end = (
-                np.datetime64(ds.attrs["time_coverage_end"][:-1]).astype(
-                    "datetime64[M]"
-                )
-                + 1
+                np.datetime64(ds.attrs["time_coverage_end"][:-1]).astype("datetime64[M]") + 1
             )
-
-            # Construct months within time coverage
             months = np.arange(time_start, time_end, 1, dtype="datetime64[M]")
-            # Compute monthly centertimes
             monthly_cts = [
-                TimeBound(rec_avg_start=month, period="AVG_MON").center
-                for month in months
+                TimeBound(rec_avg_start=month, period="AVG_MON").center for month in months
             ]
 
             logger.info("Slicing aggregated granule into monthly granules...")
 
+            solr_docs = []
             for monthly_center in monthly_cts:
                 try:
                     success = True
-                    sub_ds = ds.sel(
-                        time=np.datetime64(monthly_center), method="nearest"
-                    )
+                    sub_ds = ds.sel(time=np.datetime64(monthly_center), method="nearest")
                     sub_ds_time = sub_ds.time.values
 
-                    # Check if slice is within +/- 7 day tolerance
                     if not (
                         sub_ds_time >= monthly_center - np.timedelta64(7, "D")
                         and sub_ds_time <= monthly_center + np.timedelta64(7, "D")
@@ -246,7 +266,6 @@ class CMR_Harvester(Harvester):
                         str(monthly_center.astype("datetime64[M]")), "%Y-%m"
                     )
                     filename_time = str(time_dt)[:10].replace("-", "")
-
                     slice_filename = f"{self.ds_name}_{filename_time}.nc"
                     slice_local_fp = os.path.join(
                         self.target_dir, str(time_dt.year), slice_filename
@@ -271,7 +290,14 @@ class CMR_Harvester(Harvester):
                 )
                 monthly_granule.update_item(self.solr_docs, success)
                 monthly_granule.update_descendant(self.descendant_docs, success)
-                self.updated_solr_docs.extend(monthly_granule.get_solr_docs())
+                solr_docs.extend(monthly_granule.get_solr_docs())
+            return solr_docs
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [executor.submit(process_granule, *args) for args in to_process]
+            for future in as_completed(futures):
+                with lock:
+                    self.updated_solr_docs.extend(future.result())
 
         logger.info(f"Downloading {self.ds_name} complete")
 
@@ -291,7 +317,7 @@ class CMR_Harvester(Harvester):
         url_dict = {
             granule.url.split("RDEFT4_")[-1].split(".")[0]: granule
             for granule in self.cmr_granules
-        }  # granule end date:url
+        }
 
         end_of_month_granules = []
         for month_end in end_of_month:
@@ -306,45 +332,51 @@ class CMR_Harvester(Harvester):
                         end_of_month_granules.append(url_dict[month_end_str])
                         break
 
-        self.cmr_granules: Iterable[CMRGranule] = end_of_month_granules
-
-        for cmr_granule in self.cmr_granules:
+        to_process = []
+        for cmr_granule in end_of_month_granules:
             filename = cmr_granule.url.split("/")[-1]
             if "NRT" in filename:
                 continue
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
-            dt = datetime.strptime(date, self.filename_date_fmt)
-
-            # Force date to be first of the month
-            dt = dt.replace(day=1)
-
+            dt = datetime.strptime(date, self.filename_date_fmt).replace(day=1)
             if not ((self.start <= dt) and (self.end >= dt)):
                 continue
+            to_process.append((cmr_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
-
             local_fp = os.path.join(self.target_dir, year, filename)
             os.makedirs(os.path.join(self.target_dir, year), exist_ok=True)
 
-            if self.check_update(filename, cmr_granule.mod_time):
-                success = True
-                granule = Granule(
-                    self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
-                )
+            if not self.check_update(filename, cmr_granule.mod_time):
+                return []
 
-                if self.need_to_download(granule):
-                    logger.info(f"Downloading {filename} to {local_fp}")
-                    try:
-                        self.dl_file(cmr_granule.url, local_fp)
-                    except Exception:
-                        success = False
-                else:
-                    logger.debug(f"{filename} already downloaded and up to date")
+            success = True
+            granule = Granule(
+                self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
+            )
 
-                granule.update_item(self.solr_docs, success)
-                granule.update_descendant(self.descendant_docs, success)
-                self.updated_solr_docs.extend(granule.get_solr_docs())
+            if self.need_to_download(granule):
+                logger.info(f"Downloading {filename} to {local_fp}")
+                try:
+                    self.dl_file(cmr_granule.url, local_fp)
+                except Exception:
+                    success = False
+            else:
+                logger.debug(f"{filename} already downloaded and up to date")
+
+            granule.update_item(self.solr_docs, success)
+            granule.update_descendant(self.descendant_docs, success)
+            return granule.get_solr_docs()
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [executor.submit(process_granule, *args) for args in to_process]
+            for future in as_completed(futures):
+                with lock:
+                    self.updated_solr_docs.extend(future.result())
+
         logger.info(f"Downloading {self.ds_name} complete")
 
     def fetch_tolerance_filter(self):
@@ -371,7 +403,6 @@ class CMR_Harvester(Harvester):
         )
         time_end = datetime.strptime(filename_time, self.filename_date_fmt)
 
-        # Construct months within time coverage
         months = np.arange(
             time_start.strftime("%Y-%m-01"),
             time_end.strftime("%Y-%m-01"),
@@ -395,39 +426,51 @@ class CMR_Harvester(Harvester):
                     f"Granule nearest to {month} ({nearest_key}) is outside of tolerance window. Skipping."
                 )
 
-        for cmr_granule in self.cmr_granules:
+        to_process = []
+        for cmr_granule in granules_to_use:
             filename = cmr_granule.url.split("/")[-1]
             if "NRT" in filename:
                 continue
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
             dt = datetime.strptime(date, self.filename_date_fmt)
-            if not (self.start <= dt) and (self.end >= dt):
+            if not ((self.start <= dt) and (self.end >= dt)):
                 continue
+            to_process.append((cmr_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
-
             local_fp = os.path.join(self.target_dir, year, filename)
             os.makedirs(os.path.join(self.target_dir, year), exist_ok=True)
 
-            if self.check_update(filename, cmr_granule.mod_time):
-                success = True
-                granule = Granule(
-                    self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
-                )
+            if not self.check_update(filename, cmr_granule.mod_time):
+                return []
 
-                if self.need_to_download(granule):
-                    logger.info(f"Downloading {filename} to {local_fp}")
-                    try:
-                        self.dl_file(cmr_granule.url, local_fp)
-                    except Exception:
-                        success = False
-                else:
-                    logger.debug(f"{filename} already downloaded and up to date")
+            success = True
+            granule = Granule(
+                self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
+            )
 
-                granule.update_item(self.solr_docs, success)
-                granule.update_descendant(self.descendant_docs, success)
-                self.updated_solr_docs.extend(granule.get_solr_docs())
+            if self.need_to_download(granule):
+                logger.info(f"Downloading {filename} to {local_fp}")
+                try:
+                    self.dl_file(cmr_granule.url, local_fp)
+                except Exception:
+                    success = False
+            else:
+                logger.debug(f"{filename} already downloaded and up to date")
+
+            granule.update_item(self.solr_docs, success)
+            granule.update_descendant(self.descendant_docs, success)
+            return granule.get_solr_docs()
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [executor.submit(process_granule, *args) for args in to_process]
+            for future in as_completed(futures):
+                with lock:
+                    self.updated_solr_docs.extend(future.result())
+
         logger.info(f"Downloading {self.ds_name} complete")
 
 

--- a/ecco_pipeline/harvesters/cmr_harvester.py
+++ b/ecco_pipeline/harvesters/cmr_harvester.py
@@ -17,7 +17,7 @@ from utils.processing_utils.records import TimeBound
 
 logger = logging.getLogger("pipeline")
 
-MAX_WORKERS = 10
+MAX_WORKERS = 3
 CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 

--- a/ecco_pipeline/harvesters/cmr_harvester.py
+++ b/ecco_pipeline/harvesters/cmr_harvester.py
@@ -101,13 +101,15 @@ class CMR_Harvester(Harvester):
                 continue
             to_process.append((cmr_granule, filename, dt))
 
+        for _, _, dt in to_process:
+            os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
+
         lock = threading.Lock()
 
         def process_monthly_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
             month = str(dt.month)
             local_fp = os.path.join(self.target_dir, year, filename)
-            os.makedirs(os.path.join(self.target_dir, year), exist_ok=True)
 
             native_granule = Granule(
                 self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
@@ -158,21 +160,25 @@ class CMR_Harvester(Harvester):
                     except Exception:
                         continue
 
-                    mid_date = (
-                        var_ds.delta_time_beg.values[0]
-                        + (
-                            (
-                                var_ds.delta_time_end.values[0]
-                                - var_ds.delta_time_beg.values[0]
+                    try:
+                        mid_date = (
+                            var_ds.delta_time_beg.values[0]
+                            + (
+                                (
+                                    var_ds.delta_time_end.values[0]
+                                    - var_ds.delta_time_beg.values[0]
+                                )
+                                / 2
                             )
-                            / 2
-                        )
-                    ).astype(str)[:10]
-                    time_val = np.datetime64(mid_date).astype("datetime64[ns]")
-                    time_var_ds = var_ds.expand_dims({"time": [time_val]})
-                    time_var_ds = time_var_ds[[field.name for field in self.fields]]
-                    merged_ds = xr.merge([base_ds, time_var_ds])
-                    merged_ds.to_netcdf(daily_local_fp)
+                        ).astype(str)[:10]
+                        time_val = np.datetime64(mid_date).astype("datetime64[ns]")
+                        time_var_ds = var_ds.expand_dims({"time": [time_val]})
+                        time_var_ds = time_var_ds[[field.name for field in self.fields]]
+                        merged_ds = xr.merge([base_ds, time_var_ds])
+                        merged_ds.to_netcdf(daily_local_fp)
+                        merged_ds.close()
+                    finally:
+                        var_ds.close()
 
                     try:
                         daily_dt = datetime(int(year), int(month), i)
@@ -190,9 +196,13 @@ class CMR_Harvester(Harvester):
                         logger.debug(
                             f"{year}-{str(month).zfill(2)}-{day_number} unable to be sliced. Daily data likely missing in monthly file."
                         )
+
+                base_ds.close()
             return solr_docs
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        # xarray/netCDF4 operations are CPU-bound — 1 worker avoids core saturation
+        # while still freeing the main thread during I/O waits.
+        with ThreadPoolExecutor(max_workers=1) as executor:
             futures = [
                 executor.submit(process_monthly_granule, *args) for args in to_process
             ]

--- a/ecco_pipeline/harvesters/enumeration/catds_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/catds_enumerator.py
@@ -22,7 +22,7 @@ def search_catds(harvester: Harvester):
     for row in data.find_all("tr")[3:-1]:
         tokens = row.find_all("td")
         url = os.path.join(ds_url, tokens[1].find("a")["href"])
-        mod_time = datetime.strptime(tokens[2].text, "%Y-%m-%d %H:%M  ")
+        mod_time = datetime.strptime(tokens[2].text.strip(), "%Y-%m-%d %H:%M")
         all_granules.append(CATDSGranule(url, mod_time))
     logger.info(f"Found {len(all_granules)} possible granules. Checking for updates...")
     return all_granules

--- a/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -11,31 +12,55 @@ logger = logging.getLogger("pipeline")
 
 
 NSIDC_URL = "https://noaadata.apps.nsidc.org/NOAA/"
+MAX_WORKERS = 10
+
+
+def _fetch_year_granules(ds_hemi_url: str, year: str) -> list:
+    ds_hemi_year_url = os.path.join(ds_hemi_url, year)
+    r = requests.get(ds_hemi_year_url)
+    r.raise_for_status()
+    data = BeautifulSoup(r.text, "html.parser")
+    granules = []
+    for link in data.find_all("a")[1:]:
+        url = os.path.join(ds_hemi_year_url, link["href"])
+        tokens = link.next_sibling.split()
+        mod_time = datetime.strptime(tokens[0] + " " + tokens[1], "%d-%b-%Y %H:%M")
+        granules.append(NSIDCGranule(url, mod_time))
+    return granules
 
 
 def search_nsidc(harvester: Harvester):
     logger.info(f"Searching NSIDC for {harvester.ds_name} granules...")
     date_range = range(harvester.start.year, harvester.end.year + 1)
     all_granules = []
+
+    # Collect (hemi_url, year) pairs to fetch concurrently
+    hemi_year_pairs = []
     for hemi in ["north", "south"]:
         if harvester.ddir:
-            ds_hemi_url = os.path.join(NSIDC_URL, harvester.ds_name, harvester.ddir, hemi, "daily")
+            ds_hemi_url = os.path.join(
+                NSIDC_URL, harvester.ds_name, harvester.ddir, hemi, "daily"
+            )
         else:
             ds_hemi_url = os.path.join(NSIDC_URL, harvester.ds_name, hemi, "daily")
+
         r = requests.get(ds_hemi_url)
+        r.raise_for_status()
         data = BeautifulSoup(r.text, "html.parser")
         years = [link["href"].replace("/", "") for link in data.find_all("a")[1:]]
         for year in years:
-            if int(year) not in date_range:
-                continue
-            ds_hemi_year_url = os.path.join(ds_hemi_url, year)
-            r = requests.get(ds_hemi_year_url)
-            data = BeautifulSoup(r.text, "html.parser")
-            for link in data.find_all("a")[1:]:
-                url = os.path.join(ds_hemi_year_url, link["href"])
-                tokens = link.next_sibling.split()
-                mod_time = datetime.strptime(tokens[0] + " " + tokens[1], "%d-%b-%Y %H:%M")
-                all_granules.append(NSIDCGranule(url, mod_time))
+            if int(year) in date_range:
+                hemi_year_pairs.append((ds_hemi_url, year))
+
+    # Fetch all (hemi, year) directory listings concurrently
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = {
+            executor.submit(_fetch_year_granules, ds_hemi_url, year): (ds_hemi_url, year)
+            for ds_hemi_url, year in hemi_year_pairs
+        }
+        for future in as_completed(futures):
+            all_granules.extend(future.result())
+
     logger.info(f"Found {len(all_granules)} possible granules. Checking for updates...")
     return all_granules
 

--- a/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("pipeline")
 
 
 NSIDC_URL = "https://noaadata.apps.nsidc.org/NOAA/"
-MAX_WORKERS = 3
+MAX_WORKERS = 4
 
 
 def _fetch_year_granules(ds_hemi_url: str, year: str) -> list:

--- a/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/nsidc_enumerator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("pipeline")
 
 
 NSIDC_URL = "https://noaadata.apps.nsidc.org/NOAA/"
-MAX_WORKERS = 10
+MAX_WORKERS = 3
 
 
 def _fetch_year_granules(ds_hemi_url: str, year: str) -> list:

--- a/ecco_pipeline/harvesters/enumeration/osisaf_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/osisaf_enumerator.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -11,10 +12,37 @@ logger = logging.getLogger("pipeline")
 
 
 OSISAF_URL = "https://thredds.met.no/thredds/catalog/osisaf/met.no/"
+MAX_WORKERS = 10
+
+
+def _fetch_xml(url: str) -> BeautifulSoup:
+    r = requests.get(url)
+    r.raise_for_status()
+    return BeautifulSoup(r.text, "xml")
+
+
+def _granules_from_dataset(data: BeautifulSoup) -> list:
+    granules = []
+    for dataset in data.find_all("dataset"):
+        for granule in dataset.find_all("dataset"):
+            url = os.path.join(
+                "https://thredds.met.no/thredds/fileServer/", granule["urlPath"]
+            )
+            mod_time = datetime.strptime(
+                granule.find("date").text, "%Y-%m-%dT%H:%M:%SZ"
+            )
+            granules.append(OSISAFGranule(url, mod_time))
+    return granules
+
+
+def _fetch_month_granules(base_url: str, year_title: str, month_dir) -> list:
+    month_url = os.path.join(
+        base_url, year_title, month_dir["xlink:title"], "catalog.xml"
+    )
+    return _granules_from_dataset(_fetch_xml(month_url))
 
 
 def search_osisaf(harvester: Harvester):
-    harvester.data_time_scale
     logger.info(f"Searching OSISAF for {harvester.ds_name} granules...")
 
     if harvester.data_time_scale == "monthly":
@@ -22,46 +50,78 @@ def search_osisaf(harvester: Harvester):
     else:
         base_url = os.path.join(OSISAF_URL, harvester.ddir)
 
-    session = requests.session()
-    r = session.get(os.path.join(base_url, "catalog.xml"))
-    data = BeautifulSoup(r.text, "xml")
+    root_data = _fetch_xml(os.path.join(base_url, "catalog.xml"))
+
+    start_year = harvester.start.year
+    end_year = harvester.end.year
+
+    year_dirs = []
+    for d in root_data.find_all("catalogRef"):
+        title = d["xlink:title"]
+        if "monthly" in title:
+            continue
+        try:
+            year = int(title)
+        except ValueError:
+            year_dirs.append(d)
+            continue
+        if start_year <= year <= end_year:
+            year_dirs.append(d)
 
     all_granules = []
-    for year_dir in data.find_all("catalogRef"):
-        if "monthly" in year_dir["xlink:title"]:
-            continue
-        r = session.get(os.path.join(base_url, year_dir["xlink:title"], "catalog.xml"))
-        year_data = BeautifulSoup(r.text, "xml")
-        if harvester.data_time_scale == "daily":
-            for month_dir in year_data.find_all("catalogRef"):
-                month_url = os.path.join(
-                    base_url,
-                    year_dir["xlink:title"],
-                    month_dir["xlink:title"],
-                    "catalog.xml",
-                )
-                r = session.get(month_url)
-                month_data = BeautifulSoup(r.text, "xml")
-                for dataset in month_data.find_all("dataset"):
-                    for granule in dataset.find_all("dataset"):
-                        url = os.path.join(
-                            "https://thredds.met.no/thredds/fileServer/",
-                            granule["urlPath"],
-                        )
-                        mod_time = datetime.strptime(
-                            granule.find("date").text, "%Y-%m-%dT%H:%M:%SZ"
-                        )
-                        all_granules.append(OSISAFGranule(url, mod_time))
-        else:
-            for dataset in year_data.find_all("dataset"):
-                for granule in dataset.find_all("dataset"):
-                    url = os.path.join(
-                        "https://thredds.met.no/thredds/fileServer/", granule["urlPath"]
-                    )
-                    mod_time = datetime.strptime(
-                        granule.find("date").text, "%Y-%m-%dT%H:%M:%SZ"
-                    )
-                    all_granules.append(OSISAFGranule(url, mod_time))
+
+    if harvester.data_time_scale == "daily":
+        # Fetch all year catalogs concurrently to get month listings
+        def fetch_month_dirs(year_dir):
+            year_title = year_dir["xlink:title"]
+            year_data = _fetch_xml(
+                os.path.join(base_url, year_title, "catalog.xml")
+            )
+            month_dirs = year_data.find_all("catalogRef")
+            # Filter months to only those within the requested date range
+            try:
+                year = int(year_title)
+                start_month = harvester.start.month if year == start_year else 1
+                end_month = harvester.end.month if year == end_year else 12
+                month_dirs = [
+                    md for md in month_dirs
+                    if start_month <= int(md["xlink:title"]) <= end_month
+                ]
+            except (ValueError, KeyError):
+                pass
+            return year_title, month_dirs
+
+        year_month_pairs = []
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(fetch_month_dirs, yd): yd for yd in year_dirs}
+            for future in as_completed(futures):
+                year_title, month_dirs = future.result()
+                for md in month_dirs:
+                    year_month_pairs.append((year_title, md))
+
+        # Fetch all month catalogs concurrently
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(_fetch_month_granules, base_url, year_title, month_dir)
+                for year_title, month_dir in year_month_pairs
+            ]
+            for future in as_completed(futures):
+                all_granules.extend(future.result())
+    else:
+        # Monthly: fetch all year catalogs concurrently
+        def fetch_year_granules(year_dir):
+            year_data = _fetch_xml(
+                os.path.join(base_url, year_dir["xlink:title"], "catalog.xml")
+            )
+            return _granules_from_dataset(year_data)
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(fetch_year_granules, yd) for yd in year_dirs
+            ]
+            for future in as_completed(futures):
+                all_granules.extend(future.result())
+
     logger.info(f"Found {len(all_granules)} possible granules. Checking for updates...")
     return all_granules
 

--- a/ecco_pipeline/harvesters/enumeration/osisaf_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/osisaf_enumerator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("pipeline")
 
 
 OSISAF_URL = "https://thredds.met.no/thredds/catalog/osisaf/met.no/"
-MAX_WORKERS = 3
+MAX_WORKERS = 2
 
 
 def _fetch_xml(url: str) -> BeautifulSoup:

--- a/ecco_pipeline/harvesters/enumeration/osisaf_enumerator.py
+++ b/ecco_pipeline/harvesters/enumeration/osisaf_enumerator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("pipeline")
 
 
 OSISAF_URL = "https://thredds.met.no/thredds/catalog/osisaf/met.no/"
-MAX_WORKERS = 10
+MAX_WORKERS = 3
 
 
 def _fetch_xml(url: str) -> BeautifulSoup:

--- a/ecco_pipeline/harvesters/harvesterclasses.py
+++ b/ecco_pipeline/harvesters/harvesterclasses.py
@@ -122,25 +122,20 @@ class Harvester(Dataset):
         docs = {}
         descendants_docs = {}
 
-        # Query for existing harvested docs
+        # Query for existing harvested docs — only fetch fields needed for
+        # check_update (harvest_success_b, download_time_dt) and upserts (id)
         fq = ["type_s:granule", f"dataset_s:{self.ds_name}"]
-        harvested_docs = solr_utils.solr_query(fq)
+        harvested_docs = solr_utils.solr_query(
+            fq, fl="id,filename_s,harvest_success_b,download_time_dt"
+        )
+        for doc in harvested_docs:
+            docs[doc["filename_s"]] = doc
 
-        # Dictionary of existing harvested docs
-        # harvested doc filename : solr entry for that doc
-        if len(harvested_docs) > 0:
-            for doc in harvested_docs:
-                docs[doc["filename_s"]] = doc
-
-        # Query for existing descendants docs
+        # Query for existing descendants docs — only id needed for upserts
         fq = ["type_s:descendants", f"dataset_s:{self.ds_name}"]
-        existing_descendants_docs = solr_utils.solr_query(fq)
-
-        # Dictionary of existing descendants docs
-        # descendant doc date : solr entry for that doc
-        if len(existing_descendants_docs) > 0:
-            for doc in existing_descendants_docs:
-                descendants_docs[doc["filename_s"]] = doc
+        existing_descendants_docs = solr_utils.solr_query(fq, fl="id,filename_s")
+        for doc in existing_descendants_docs:
+            descendants_docs[doc["filename_s"]] = doc
 
         return docs, descendants_docs
 
@@ -268,24 +263,15 @@ class Harvester(Dataset):
         return harvesting_status
 
     def harvester_status(self) -> str:
-        # Query for Solr failed harvest documents
-        fq = ["type_s:granule", f"dataset_s:{self.ds_name}", "harvest_success_b:false"]
-        failed_harvesting = solr_utils.solr_query(fq)
+        fq_base = ["type_s:granule", f"dataset_s:{self.ds_name}"]
+        failed_count = solr_utils.solr_count(fq_base + ["harvest_success_b:false"])
+        successful_count = solr_utils.solr_count(fq_base + ["harvest_success_b:true"])
 
-        # Query for Solr successful harvest documents
-        fq = ["type_s:granule", f"dataset_s:{self.ds_name}", "harvest_success_b:true"]
-        successful_harvesting = solr_utils.solr_query(fq)
-
-        harvest_status = "All granules successfully harvested"
-
-        if not successful_harvesting:
-            harvest_status = (
-                "No usable granules harvested (either all failed or no data collected)"
-            )
-        elif failed_harvesting:
-            harvest_status = f"{len(failed_harvesting)} harvested granules failed"
-
-        return harvest_status
+        if not successful_count:
+            return "No usable granules harvested (either all failed or no data collected)"
+        elif failed_count:
+            return f"{failed_count} harvested granules failed"
+        return "All granules successfully harvested"
 
     def ds_doc_update(self) -> bool:
         # Query for Solr dataset level document

--- a/ecco_pipeline/harvesters/nsidc_harvester.py
+++ b/ecco_pipeline/harvesters/nsidc_harvester.py
@@ -1,14 +1,18 @@
 import logging
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Iterable
 
 import requests
-from harvesters.enumeration.nsidc_enumerator import NSIDCGranule, search_nsidc
+from harvesters.enumeration.nsidc_enumerator import MAX_WORKERS, NSIDCGranule, search_nsidc
 from harvesters.harvesterclasses import Granule, Harvester
 from utils.pipeline_utils.file_utils import get_date
 
 logger = logging.getLogger("pipeline")
+
+CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 
 class NSIDC_Harvester(Harvester):
@@ -17,47 +21,61 @@ class NSIDC_Harvester(Harvester):
         self.nsidc_granules: Iterable[NSIDCGranule] = search_nsidc(self)
 
     def fetch(self):
+        # Pre-filter granules to only those within the date range
+        to_process = []
         for nsidc_granule in self.nsidc_granules:
             filename = nsidc_granule.url.split("/")[-1]
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
             dt = datetime.strptime(date, self.filename_date_fmt)
-            if not ((self.start <= dt) and (self.end >= dt)):
+            if not (self.start <= dt <= self.end):
                 continue
+            to_process.append((nsidc_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_granule(nsidc_granule: NSIDCGranule, filename: str, dt: datetime):
             year = str(dt.year)
-
             local_fp = os.path.join(self.target_dir, year, filename)
             os.makedirs(os.path.dirname(local_fp), exist_ok=True)
 
-            if self.check_update(filename, nsidc_granule.mod_time):
-                success = True
-                granule = Granule(
-                    self.ds_name,
-                    local_fp,
-                    dt,
-                    nsidc_granule.mod_time,
-                    nsidc_granule.url,
-                )
+            if not self.check_update(filename, nsidc_granule.mod_time):
+                return []
 
-                if self.need_to_download(granule):
-                    logger.info(f"Downloading {filename} to {local_fp}")
-                    try:
-                        self.dl_file(nsidc_granule.url, local_fp)
-                    except Exception:
-                        success = False
-                else:
-                    logger.debug(f"{filename} already downloaded and up to date")
+            success = True
+            granule = Granule(
+                self.ds_name, local_fp, dt, nsidc_granule.mod_time, nsidc_granule.url
+            )
 
-                granule.update_item(self.solr_docs, success)
-                granule.update_descendant(self.descendant_docs, success)
-                self.updated_solr_docs.extend(granule.get_solr_docs())
+            if self.need_to_download(granule):
+                logger.info(f"Downloading {filename} to {local_fp}")
+                try:
+                    self.dl_file(nsidc_granule.url, local_fp)
+                except Exception:
+                    success = False
+            else:
+                logger.debug(f"{filename} already downloaded and up to date")
+
+            granule.update_item(self.solr_docs, success)
+            granule.update_descendant(self.descendant_docs, success)
+            return granule.get_solr_docs()
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(process_granule, *args) for args in to_process
+            ]
+            for future in as_completed(futures):
+                docs = future.result()
+                with lock:
+                    self.updated_solr_docs.extend(docs)
+
         logger.info(f"Downloading {self.ds_name} complete")
 
     def dl_file(self, src: str, dst: str):
-        r = requests.get(src)
-        r.raise_for_status()
-        open(dst, "wb").write(r.content)
+        with requests.get(src, stream=True) as r:
+            r.raise_for_status()
+            with open(dst, "wb") as f:
+                for chunk in r.iter_content(chunk_size=CHUNK_SIZE):
+                    f.write(chunk)
 
 
 def harvester(config: dict) -> str:

--- a/ecco_pipeline/harvesters/nsidc_harvester.py
+++ b/ecco_pipeline/harvesters/nsidc_harvester.py
@@ -31,12 +31,14 @@ class NSIDC_Harvester(Harvester):
                 continue
             to_process.append((nsidc_granule, filename, dt))
 
+        for _, _, dt in to_process:
+            os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
+
         lock = threading.Lock()
 
         def process_granule(nsidc_granule: NSIDCGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
-            os.makedirs(os.path.dirname(local_fp), exist_ok=True)
 
             if not self.check_update(filename, nsidc_granule.mod_time):
                 return []
@@ -71,7 +73,7 @@ class NSIDC_Harvester(Harvester):
         logger.info(f"Downloading {self.ds_name} complete")
 
     def dl_file(self, src: str, dst: str):
-        with requests.get(src, stream=True) as r:
+        with requests.get(src, stream=True, timeout=120) as r:
             r.raise_for_status()
             with open(dst, "wb") as f:
                 for chunk in r.iter_content(chunk_size=CHUNK_SIZE):

--- a/ecco_pipeline/harvesters/osisaf_harvester.py
+++ b/ecco_pipeline/harvesters/osisaf_harvester.py
@@ -1,14 +1,22 @@
 import logging
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Iterable
 
 import requests
-from harvesters.enumeration.osisaf_enumerator import OSISAFGranule, search_osisaf
+from harvesters.enumeration.osisaf_enumerator import (
+    MAX_WORKERS,
+    OSISAFGranule,
+    search_osisaf,
+)
 from harvesters.harvesterclasses import Granule, Harvester
 from utils.pipeline_utils.file_utils import get_date
 
 logger = logging.getLogger("pipeline")
+
+CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 
 class OSISAF_Harvester(Harvester):
@@ -17,51 +25,64 @@ class OSISAF_Harvester(Harvester):
         self.osisaf_granules: Iterable[OSISAFGranule] = search_osisaf(self)
 
     def fetch(self):
+        # Pre-filter granules to only those within the date range
+        to_process = []
         for osisaf_granule in self.osisaf_granules:
             filename = osisaf_granule.url.split("/")[-1]
-            # Get date from filename and convert to dt object
             date = get_date(self.filename_date_regex, filename)
             dt = datetime.strptime(date, self.filename_date_fmt)
-            if not ((self.start <= dt) and (self.end >= dt)):
+            if not (self.start <= dt <= self.end):
                 continue
-
             if "icdrft" in filename:
                 logger.debug("Skipping fast track file for date")
                 continue
+            to_process.append((osisaf_granule, filename, dt))
 
+        lock = threading.Lock()
+
+        def process_granule(osisaf_granule: OSISAFGranule, filename: str, dt: datetime):
             year = str(dt.year)
-
             local_fp = os.path.join(self.target_dir, year, filename)
             os.makedirs(os.path.dirname(local_fp), exist_ok=True)
 
-            if self.check_update(filename, osisaf_granule.mod_time):
-                success = True
-                granule = Granule(
-                    self.ds_name,
-                    local_fp,
-                    dt,
-                    osisaf_granule.mod_time,
-                    osisaf_granule.url,
-                )
+            if not self.check_update(filename, osisaf_granule.mod_time):
+                return []
 
-                if self.need_to_download(granule):
-                    logger.info(f"Downloading {filename} to {local_fp}")
-                    try:
-                        self.dl_file(osisaf_granule.url, local_fp)
-                    except Exception:
-                        success = False
-                else:
-                    logger.debug(f"{filename} already downloaded and up to date")
+            success = True
+            granule = Granule(
+                self.ds_name, local_fp, dt, osisaf_granule.mod_time, osisaf_granule.url
+            )
 
-                granule.update_item(self.solr_docs, success)
-                granule.update_descendant(self.descendant_docs, success)
-                self.updated_solr_docs.extend(granule.get_solr_docs())
+            if self.need_to_download(granule):
+                logger.info(f"Downloading {filename} to {local_fp}")
+                try:
+                    self.dl_file(osisaf_granule.url, local_fp)
+                except Exception:
+                    success = False
+            else:
+                logger.debug(f"{filename} already downloaded and up to date")
+
+            granule.update_item(self.solr_docs, success)
+            granule.update_descendant(self.descendant_docs, success)
+            return granule.get_solr_docs()
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = [
+                executor.submit(process_granule, *args) for args in to_process
+            ]
+            for future in as_completed(futures):
+                docs = future.result()
+                with lock:
+                    self.updated_solr_docs.extend(docs)
+
         logger.info(f"Downloading {self.ds_name} complete")
 
     def dl_file(self, src: str, dst: str):
-        r = requests.get(src)
-        r.raise_for_status()
-        open(dst, "wb").write(r.content)
+        with requests.get(src, stream=True) as r:
+            r.raise_for_status()
+            with open(dst, "wb") as f:
+                for chunk in r.iter_content(chunk_size=CHUNK_SIZE):
+                    f.write(chunk)
 
 
 def harvester(config: dict) -> str:

--- a/ecco_pipeline/harvesters/osisaf_harvester.py
+++ b/ecco_pipeline/harvesters/osisaf_harvester.py
@@ -39,6 +39,8 @@ class OSISAF_Harvester(Harvester):
             to_process.append((osisaf_granule, filename, dt))
 
         lock = threading.Lock()
+        total = len(to_process)
+        completed = 0
 
         def process_granule(osisaf_granule: OSISAFGranule, filename: str, dt: datetime):
             year = str(dt.year)
@@ -74,11 +76,14 @@ class OSISAF_Harvester(Harvester):
                 docs = future.result()
                 with lock:
                     self.updated_solr_docs.extend(docs)
+                    completed += 1
+                    if completed % 500 == 0:
+                        logger.info(f"{self.ds_name}: processed {completed}/{total} granules")
 
         logger.info(f"Downloading {self.ds_name} complete")
 
     def dl_file(self, src: str, dst: str):
-        with requests.get(src, stream=True) as r:
+        with requests.get(src, stream=True, timeout=120) as r:
             r.raise_for_status()
             with open(dst, "wb") as f:
                 for chunk in r.iter_content(chunk_size=CHUNK_SIZE):

--- a/ecco_pipeline/harvesters/osisaf_harvester.py
+++ b/ecco_pipeline/harvesters/osisaf_harvester.py
@@ -38,6 +38,10 @@ class OSISAF_Harvester(Harvester):
                 continue
             to_process.append((osisaf_granule, filename, dt))
 
+        # Pre-create all year directories to avoid repeated syscalls in workers
+        for _, _, dt in to_process:
+            os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
+
         lock = threading.Lock()
         total = len(to_process)
         completed = 0
@@ -45,7 +49,6 @@ class OSISAF_Harvester(Harvester):
         def process_granule(osisaf_granule: OSISAFGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
-            os.makedirs(os.path.dirname(local_fp), exist_ok=True)
 
             if not self.check_update(filename, osisaf_granule.mod_time):
                 return []

--- a/ecco_pipeline/tests/harvesters/test_catds_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_catds_harvester.py
@@ -185,11 +185,12 @@ class CATDSHarvesterTestCase(unittest.TestCase):
 @patch("harvesters.harvesterclasses.solr_utils.solr_query")
 @patch("harvesters.harvesterclasses.solr_utils.clean_solr")
 @patch("harvesters.harvesterclasses.solr_utils.solr_update")
+@patch("harvesters.harvesterclasses.solr_utils.solr_count")
 @patch("harvesters.catds_harvester.search_catds")
 class CATDSHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function(self, mock_search, mock_update, mock_clean, mock_query):
+    def test_harvester_function(self, mock_search, mock_count, mock_update, mock_clean, mock_query):
         """Test the harvester() function runs complete workflow."""
         mock_query.return_value = []
         mock_search.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
@@ -276,13 +276,19 @@ class CMRHarvesterTestCase(unittest.TestCase):
         mock_query_instance.query.return_value = []
         mock_cmr_query.return_value = mock_query_instance
 
-        # First call fails, second succeeds
+        # First call fails, second succeeds.
+        # __exit__ must return False so the context manager does not suppress
+        # the exception raised by raise_for_status — otherwise the retry loop
+        # never executes.
         mock_fail = MagicMock()
+        mock_fail.__enter__ = MagicMock(return_value=mock_fail)
+        mock_fail.__exit__ = MagicMock(return_value=False)
         mock_fail.raise_for_status.side_effect = Exception("First attempt failed")
 
         mock_success = MagicMock()
-        mock_success.content = b"content"
-        mock_success.raise_for_status = MagicMock()
+        mock_success.__enter__ = MagicMock(return_value=mock_success)
+        mock_success.__exit__ = MagicMock(return_value=False)
+        mock_success.iter_content.return_value = [b"content"]
 
         mock_requests.side_effect = [mock_fail, mock_success]
 
@@ -305,11 +311,12 @@ class CMRHarvesterTestCase(unittest.TestCase):
 @patch("harvesters.harvesterclasses.solr_utils.solr_query")
 @patch("harvesters.harvesterclasses.solr_utils.clean_solr")
 @patch("harvesters.harvesterclasses.solr_utils.solr_update")
+@patch("harvesters.harvesterclasses.solr_utils.solr_count")
 @patch("harvesters.cmr_harvester.CMRQuery")
 class CMRHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function_standard(self, mock_cmr_query, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_standard(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
         """Test the harvester() function runs standard fetch workflow."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -328,7 +335,7 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
                 self.assertIsInstance(status, str)
                 mock_update.assert_called()
 
-    def test_harvester_function_atl20(self, mock_cmr_query, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_atl20(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
         """Test the harvester() function calls fetch_atl_daily for ATL20."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -347,7 +354,7 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
                     status = harvester(config)
                     mock_fetch.assert_called_once()
 
-    def test_harvester_function_tellus_grac_grfo(self, mock_cmr_query, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_tellus_grac_grfo(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
         """Test the harvester() function calls fetch_tellus_grac_grfo for TELLUS dataset."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -366,7 +373,7 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
                     status = harvester(config)
                     mock_fetch.assert_called_once()
 
-    def test_harvester_function_rdeft4(self, mock_cmr_query, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_rdeft4(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
         """Test the harvester() function calls fetch_rdeft4 for RDEFT4."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -385,7 +392,7 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
                     status = harvester(config)
                     mock_fetch.assert_called_once()
 
-    def test_harvester_function_tellus_tolerance(self, mock_cmr_query, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_tellus_tolerance(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
         """Test the harvester() function calls fetch_tolerance_filter for other TELLUS datasets."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()

--- a/ecco_pipeline/tests/harvesters/test_harvesterclasses.py
+++ b/ecco_pipeline/tests/harvesters/test_harvesterclasses.py
@@ -415,12 +415,13 @@ class HarvesterTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                harvester = Harvester(config)
-                harvester.updated_solr_docs = []
+                with patch("harvesters.harvesterclasses.solr_utils.solr_count", return_value=0):
+                    harvester = Harvester(config)
+                    harvester.updated_solr_docs = []
 
-                status = harvester.post_fetch("https://example.com/source")
+                    status = harvester.post_fetch("https://example.com/source")
 
-                self.assertIn("harvested", status.lower())
+                    self.assertIn("harvested", status.lower())
 
     @patch("harvesters.harvesterclasses.solr_utils.solr_update")
     def test_post_fetch_with_updates(self, mock_update, mock_clean, mock_query):
@@ -434,59 +435,50 @@ class HarvesterTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                harvester = Harvester(config)
-                harvester.updated_solr_docs = [
-                    {
-                        "type_s": "granule",
-                        "harvest_success_b": True,
-                        "download_time_dt": "2020-01-01T00:00:00Z",
-                        "date_s": "2020-01-01T00:00:00Z"
-                    }
-                ]
+                with patch("harvesters.harvesterclasses.solr_utils.solr_count", return_value=0):
+                    harvester = Harvester(config)
+                    harvester.updated_solr_docs = [
+                        {
+                            "type_s": "granule",
+                            "harvest_success_b": True,
+                            "download_time_dt": "2020-01-01T00:00:00Z",
+                            "date_s": "2020-01-01T00:00:00Z"
+                        }
+                    ]
 
-                status = harvester.post_fetch("https://example.com/source")
+                    status = harvester.post_fetch("https://example.com/source")
 
-                # Verify solr_update was called
-                self.assertTrue(mock_update.called)
+                    # Verify solr_update was called
+                    self.assertTrue(mock_update.called)
 
     def test_harvester_status_all_success(self, mock_clean, mock_query):
         """Test harvester_status when all granules succeeded."""
-        # First call for init, then for status checks
-        mock_query.side_effect = [
-            [],  # Initial granule query
-            [],  # Initial descendant query
-            [],  # Failed granules query
-            [{"id": "1"}]  # Successful granules query
-        ]
+        mock_query.return_value = []
 
         config = self.get_mock_config()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                harvester = Harvester(config)
-                status = harvester.harvester_status()
+                with patch("harvesters.harvesterclasses.solr_utils.solr_count", side_effect=[0, 1]):
+                    harvester = Harvester(config)
+                    status = harvester.harvester_status()
 
-                self.assertEqual(status, "All granules successfully harvested")
+                    self.assertEqual(status, "All granules successfully harvested")
 
     def test_harvester_status_with_failures(self, mock_clean, mock_query):
         """Test harvester_status when some granules failed."""
-        # First call for init, then for status checks
-        mock_query.side_effect = [
-            [],  # Initial granule query
-            [],  # Initial descendant query
-            [{"id": "1"}, {"id": "2"}],  # Failed granules query
-            [{"id": "3"}]  # Successful granules query
-        ]
+        mock_query.return_value = []
 
         config = self.get_mock_config()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                harvester = Harvester(config)
-                status = harvester.harvester_status()
+                with patch("harvesters.harvesterclasses.solr_utils.solr_count", side_effect=[2, 1]):
+                    harvester = Harvester(config)
+                    status = harvester.harvester_status()
 
-                self.assertIn("2", status)
-                self.assertIn("failed", status)
+                    self.assertIn("2", status)
+                    self.assertIn("failed", status)
 
     def test_get_solr_docs_with_existing(self, mock_clean, mock_query):
         """Test get_solr_docs retrieves existing documents."""

--- a/ecco_pipeline/tests/harvesters/test_nsidc_enumerator.py
+++ b/ecco_pipeline/tests/harvesters/test_nsidc_enumerator.py
@@ -64,30 +64,20 @@ class SearchNSIDCTestCase(unittest.TestCase):
         """Test basic NSIDC search functionality."""
         harvester = self.get_mock_harvester()
 
-        # Setup mock responses
-        mock_responses = []
+        # The enumerator fetches year listings for both hemispheres sequentially,
+        # then fetches file listings concurrently. Order must match that flow.
+        year_response = MagicMock()
+        year_response.text = self.get_year_listing_html()
 
-        # Response for north hemisphere year listing
-        north_year_response = MagicMock()
-        north_year_response.text = self.get_year_listing_html()
-        mock_responses.append(north_year_response)
+        file_response = MagicMock()
+        file_response.text = self.get_file_listing_html()
 
-        # Response for 2020 file listing (north)
-        north_file_response = MagicMock()
-        north_file_response.text = self.get_file_listing_html()
-        mock_responses.append(north_file_response)
-
-        # Response for south hemisphere year listing
-        south_year_response = MagicMock()
-        south_year_response.text = self.get_year_listing_html()
-        mock_responses.append(south_year_response)
-
-        # Response for 2020 file listing (south)
-        south_file_response = MagicMock()
-        south_file_response.text = self.get_file_listing_html()
-        mock_responses.append(south_file_response)
-
-        mock_get.side_effect = mock_responses
+        mock_get.side_effect = [
+            year_response,   # north hemisphere year listing (sequential)
+            year_response,   # south hemisphere year listing (sequential)
+            file_response,   # north 2020 file listing (concurrent)
+            file_response,   # south 2020 file listing (concurrent)
+        ]
 
         granules = search_nsidc(harvester)
 

--- a/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
@@ -192,11 +192,12 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
 @patch("harvesters.harvesterclasses.solr_utils.solr_query")
 @patch("harvesters.harvesterclasses.solr_utils.clean_solr")
 @patch("harvesters.harvesterclasses.solr_utils.solr_update")
+@patch("harvesters.harvesterclasses.solr_utils.solr_count")
 @patch("harvesters.nsidc_harvester.search_nsidc")
 class NSIDCHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function(self, mock_search, mock_update, mock_clean, mock_query):
+    def test_harvester_function(self, mock_search, mock_count, mock_update, mock_clean, mock_query):
         """Test the harvester() function runs complete workflow."""
         mock_query.return_value = []
         mock_search.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_osisaf_enumerator.py
+++ b/ecco_pipeline/tests/harvesters/test_osisaf_enumerator.py
@@ -83,15 +83,12 @@ class SearchOSISAFTestCase(unittest.TestCase):
         </catalog>
         """
 
-    @patch("harvesters.enumeration.osisaf_enumerator.requests.session")
-    def test_search_osisaf_daily_basic(self, mock_session_class):
+    @patch("harvesters.enumeration.osisaf_enumerator.requests.get")
+    def test_search_osisaf_daily_basic(self, mock_get_fn):
         """Test basic OSISAF daily search functionality."""
         harvester = self.get_mock_harvester("daily")
 
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
-
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if url.endswith("catalog.xml") and "/2020/" not in url and "/01/" not in url and "/02/" not in url:
                 response.text = self.get_year_catalog_xml()
@@ -101,22 +98,19 @@ class SearchOSISAFTestCase(unittest.TestCase):
                 response.text = self.get_daily_catalog_xml()
             return response
 
-        mock_session.get.side_effect = mock_get
+        mock_get_fn.side_effect = mock_get
 
         granules = search_osisaf(harvester)
 
         self.assertGreater(len(granules), 0)
         self.assertIsInstance(granules[0], OSISAFGranule)
 
-    @patch("harvesters.enumeration.osisaf_enumerator.requests.session")
-    def test_search_osisaf_monthly(self, mock_session_class):
+    @patch("harvesters.enumeration.osisaf_enumerator.requests.get")
+    def test_search_osisaf_monthly(self, mock_get_fn):
         """Test OSISAF monthly search functionality."""
         harvester = self.get_mock_harvester("monthly")
 
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
-
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "monthly/catalog.xml" in url and "/2020/" not in url:
                 response.text = self.get_year_catalog_xml()
@@ -126,7 +120,7 @@ class SearchOSISAFTestCase(unittest.TestCase):
                 response.text = self.get_monthly_file_catalog_xml()
             return response
 
-        mock_session.get.side_effect = mock_get
+        mock_get_fn.side_effect = mock_get
 
         granules = search_osisaf(harvester)
 
@@ -134,17 +128,14 @@ class SearchOSISAFTestCase(unittest.TestCase):
         for granule in granules:
             self.assertIsInstance(granule, OSISAFGranule)
 
-    @patch("harvesters.enumeration.osisaf_enumerator.requests.session")
-    def test_search_osisaf_url_construction(self, mock_session_class):
+    @patch("harvesters.enumeration.osisaf_enumerator.requests.get")
+    def test_search_osisaf_url_construction(self, mock_get_fn):
         """Test that correct URLs are constructed."""
         harvester = self.get_mock_harvester("daily")
 
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
-
         calls = []
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             calls.append(url)
             response = MagicMock()
             if url.endswith("catalog.xml") and "/2020/" not in url and "/01/" not in url and "/02/" not in url:
@@ -155,7 +146,7 @@ class SearchOSISAFTestCase(unittest.TestCase):
                 response.text = self.get_daily_catalog_xml()
             return response
 
-        mock_session.get.side_effect = mock_get
+        mock_get_fn.side_effect = mock_get
 
         search_osisaf(harvester)
 
@@ -163,15 +154,12 @@ class SearchOSISAFTestCase(unittest.TestCase):
         self.assertTrue(any("thredds.met.no" in call for call in calls))
         self.assertTrue(any("osisaf" in call for call in calls))
 
-    @patch("harvesters.enumeration.osisaf_enumerator.requests.session")
-    def test_search_osisaf_granule_attributes(self, mock_session_class):
+    @patch("harvesters.enumeration.osisaf_enumerator.requests.get")
+    def test_search_osisaf_granule_attributes(self, mock_get_fn):
         """Test that granules have correct attributes."""
         harvester = self.get_mock_harvester("daily")
 
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
-
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if url.endswith("catalog.xml") and "/2020/" not in url and "/01/" not in url and "/02/" not in url:
                 response.text = self.get_year_catalog_xml()
@@ -181,7 +169,7 @@ class SearchOSISAFTestCase(unittest.TestCase):
                 response.text = self.get_daily_catalog_xml()
             return response
 
-        mock_session.get.side_effect = mock_get
+        mock_get_fn.side_effect = mock_get
 
         granules = search_osisaf(harvester)
 
@@ -190,17 +178,14 @@ class SearchOSISAFTestCase(unittest.TestCase):
             self.assertIn("fileServer", granule.url)
             self.assertIsInstance(granule.mod_time, datetime)
 
-    @patch("harvesters.enumeration.osisaf_enumerator.requests.session")
-    def test_search_osisaf_skips_monthly_dir(self, mock_session_class):
+    @patch("harvesters.enumeration.osisaf_enumerator.requests.get")
+    def test_search_osisaf_skips_monthly_dir(self, mock_get_fn):
         """Test that monthly directory is skipped in daily search."""
         harvester = self.get_mock_harvester("daily")
 
-        mock_session = MagicMock()
-        mock_session_class.return_value = mock_session
-
         calls = []
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             calls.append(url)
             response = MagicMock()
             if url.endswith("catalog.xml") and "/2020/" not in url and "/01/" not in url and "/02/" not in url:
@@ -211,7 +196,7 @@ class SearchOSISAFTestCase(unittest.TestCase):
                 response.text = self.get_daily_catalog_xml()
             return response
 
-        mock_session.get.side_effect = mock_get
+        mock_get_fn.side_effect = mock_get
 
         search_osisaf(harvester)
 

--- a/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
@@ -157,11 +157,12 @@ class OSISAFHarvesterTestCase(unittest.TestCase):
 @patch("harvesters.harvesterclasses.solr_utils.solr_query")
 @patch("harvesters.harvesterclasses.solr_utils.clean_solr")
 @patch("harvesters.harvesterclasses.solr_utils.solr_update")
+@patch("harvesters.harvesterclasses.solr_utils.solr_count")
 @patch("harvesters.osisaf_harvester.search_osisaf")
 class OSISAFHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function(self, mock_search, mock_update, mock_clean, mock_query):
+    def test_harvester_function(self, mock_search, mock_count, mock_update, mock_clean, mock_query):
         """Test the harvester() function runs complete workflow."""
         mock_query.return_value = []
         mock_search.return_value = []

--- a/ecco_pipeline/utils/pipeline_utils/init_pipeline.py
+++ b/ecco_pipeline/utils/pipeline_utils/init_pipeline.py
@@ -156,6 +156,7 @@ def update_solr_grid(grid_name: str, grid_type: str, grid_file_path: str):
                     "id": grid_metadata["id"],
                     "grid_type_s": {"set": grid_type},
                     "grid_name_s": {"set": grid_name},
+                    "grid_path_s": {"set": str(grid_file_path)},
                     "grid_checksum_s": {"set": current_checksum},
                     "date_added_dt": {
                         "set": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -179,17 +180,16 @@ def grids_to_solr(grids_to_use: Iterable[str] = []):
 
     grids = []
     for grid_file_path in grid_files:
-        grid_file_name = os.path.basename(grid_file_path)
         ds = xr.open_dataset(grid_file_path)
         # Assumes grids conform to metadata standard (see documentation)
         grid_name = ds.attrs["name"]
         grid_type = ds.attrs["type"]
-        grids.append((grid_name, grid_type, grid_file_name))
-        logger.debug(f"Loaded {grid_name} {grid_type} {grid_file_name}")
+        grids.append((grid_name, grid_type, grid_file_path))
+        logger.debug(f"Loaded {grid_name} {grid_type} {grid_file_path}")
 
     # Create Solr grid-type document for each missing grid type
-    for grid_name, grid_type, grid_file_name in grids:
-        logger.debug(f"Uploading solr grid {grid_name} {grid_type} {grid_file_name}")
+    for grid_name, grid_type, grid_file_path in grids:
+        logger.debug(f"Uploading solr grid {grid_name} {grid_type} {grid_file_path}")
         update_solr_grid(grid_name, grid_type, grid_file_path)
 
     # Verify grid names supplied exist on Solr

--- a/ecco_pipeline/utils/pipeline_utils/solr_utils.py
+++ b/ecco_pipeline/utils/pipeline_utils/solr_utils.py
@@ -28,6 +28,24 @@ def solr_query(fq: Iterable[str], fl: str = "") -> Iterable[dict]:
     return response.json()["response"]["docs"]
 
 
+def solr_count(fq: Iterable[str]) -> int:
+    """
+    Return the number of documents matching fq without fetching any docs.
+    """
+    query_params = {"q": "*:*", "fq": fq, "rows": 0}
+    url = f"{SOLR_HOST}{SOLR_COLLECTION}/select?"
+    try:
+        response = requests.get(
+            url, params=query_params, headers={"Connection": "close"}
+        )
+    except Exception:
+        time.sleep(5)
+        response = requests.get(
+            url, params=query_params, headers={"Connection": "close"}
+        )
+    return response.json()["response"]["numFound"]
+
+
 def solr_update(update_body: Iterable[dict], r: bool = False):
     """
     Submit update to Solr

--- a/ecco_pipeline/utils/processing_utils/records.py
+++ b/ecco_pipeline/utils/processing_utils/records.py
@@ -174,10 +174,9 @@ def save_netcdf(data: xr.Dataset, output_filename: str, netcdf_output_dir: str):
 
     coord_encoding = {}
     for coord in data_DS.coords:
+        coord_encoding[coord] = {"_FillValue": None, "dtype": "float32"}
         if coord == "time" or coord == "time_bnds":
             coord_encoding[coord] = {"dtype": "int32"}
-        else:
-            coord_encoding[coord] = {"_FillValue": None}
     coord_encoding["time"] = {"units": "hours since 1980-01-01"}
 
     var_encoding = {}

--- a/ecco_pipeline/utils/processing_utils/records.py
+++ b/ecco_pipeline/utils/processing_utils/records.py
@@ -174,10 +174,10 @@ def save_netcdf(data: xr.Dataset, output_filename: str, netcdf_output_dir: str):
 
     coord_encoding = {}
     for coord in data_DS.coords:
-        coord_encoding[coord] = {"_FillValue": None, "dtype": "float32"}
-
         if coord == "time" or coord == "time_bnds":
             coord_encoding[coord] = {"dtype": "int32"}
+        else:
+            coord_encoding[coord] = {"_FillValue": None}
     coord_encoding["time"] = {"units": "hours since 1980-01-01"}
 
     var_encoding = {}


### PR DESCRIPTION
  ## Summary                                                                                                                        

  - Fix operator precedence bug in CMR date filter (affected 4 of 5 fetch methods)                                                 
  - Fix fetch_tolerance_filter computing granules_to_use but iterating self.cmr_granules instead (dead-code filtering)
  - Replace serial HTTP catalog walks with concurrent ThreadPoolExecutor fetches in OSISAF and NSIDC enumerators                   
  - Parallelize granule downloads across all four harvesters (OSISAF, NSIDC, CATDS, CMR)                                           
  - Switch all dl_file implementations from buffered (r.content) to streaming (iter_content)                                       
                                                                                                                                   
   ## Bug fixes                                                                                                                      
                                                                                                                                   
  CMR: operator precedence in date filter (cmr_harvester.py)                                                                     

  Affected fetch(), fetch_atl_daily(), fetch_tellus_grac_grfo(), and fetch_tolerance_filter(). fetch_rdeft4() was already correct. 
  
  #### Before — evaluates as: (not (self.start <= dt)) and (self.end >= dt)                                                           
  if not (self.start <= dt) and (self.end >= dt):                                                                                
                                                                                                                                   
  #### After                                                                                                                        
  if not ((self.start <= dt) and (self.end >= dt)):                                                                                
                                                                                                                                 
  CMR: fetch_tolerance_filter tolerance window was never applied                                                                   
  
  granules_to_use was computed correctly but the download loop iterated self.cmr_granules, making the entire nearest-granule       
  selection dead code. Fixed to iterate granules_to_use.                                                                         
                                                                                                                                   
   ## Performance changes                                                                                                            

   ### Enumerators

  OSISAF — for daily data, enumeration required ~131 serial HTTP requests (1 root + N years + N×12 months). Now runs two concurrent
   fan-outs via ThreadPoolExecutor: year catalogs in parallel, then month catalogs in parallel. Also skips year/month directories
  outside the configured start/end range entirely.                                                                                 
                                                                                                                                 
  NSIDC — year-directory listings for both hemispheres were fetched serially. Now collects all (hemi_url, year) pairs first, then  
  fetches all in one concurrent pass. Year-range filtering was already correct.
                                                                                                                                   
  CATDS — single flat HTML listing (one request). No enumeration changes needed.                                                   
   
  CMR — single paginated API call handled by the cmr library. No enumeration changes needed.                                       
                                                                                                                                 
   ### Harvesters (all four)                                                                                                            
                                                                                                                                 
  All fetch methods now follow the same pattern:                                                                                   
  1. Pre-filter granules into a to_process list (date range, NRT skip, dataset-specific logic)
  2. ThreadPoolExecutor(max_workers=10) for concurrent per-granule processing                                                      
  3. threading.Lock protecting appends to updated_solr_docs                                                                      
  4. dl_file uses requests.get(src, stream=True) + iter_content(chunk_size=1MB)                                                    
                                                                                                                                   
  fetch_atl_daily() parallelizes at the monthly-granule level — each worker downloads one monthly file and runs the full day 1–31  
  xarray slicing loop independently.                                                                                               
                                                                                                                                   
  CMR's dl_file retry logic was also deduplicated from copy-pasted try/except blocks into a two-iteration loop.