### PR TITLE
Solr schema improvements: date_dt migration, remove descendants, observability fields

### DIFF
--- a/ecco_pipeline/aggregations/aggregation.py
+++ b/ecco_pipeline/aggregations/aggregation.py
@@ -79,35 +79,6 @@ class Aggregation(Dataset):
     def generate_provenance(
         self, grid_name, solr_output_filepaths, aggregation_successes
     ):
-        # Query for descendants entries from this year
-        fq = ["type_s:descendants", f"dataset_s:{self.ds_name}", f"date_s:{self.year}*"]
-        existing_descendants_docs = solr_utils.solr_query(fq)
-
-        # if descendants entries already exist, update them
-        if len(existing_descendants_docs) > 0:
-            update_body = []
-            for doc in existing_descendants_docs:
-                doc_id = doc["id"]
-
-                temp_doc = {
-                    "id": doc_id,
-                    "all_aggregation_success_b": {"set": aggregation_successes},
-                }
-
-                # Add aggregation file path fields to descendants entry
-                for key, value in solr_output_filepaths.items():
-                    temp_doc[
-                        f"{grid_name}_{self.field.name}_aggregated_{key}_path_s"
-                    ] = {"set": value}
-                update_body.append(temp_doc)
-
-            r = solr_utils.solr_update(update_body, r=True)
-
-            if r.status_code != 200:
-                logger.exception(
-                    f"Failed to update Solr aggregation entry for {self.field.name} in {self.ds_name} for {self.year} and grid {grid_name}"
-                )
-
         fq = [
             f"dataset_s:{self.ds_name}",
             "type_s:aggregation",
@@ -149,12 +120,12 @@ class Aggregation(Dataset):
             "success_b:True",
             f'grid_name_s:{self.grid["grid_name_s"]}',
             f"field_s:{self.field.name}",
-            f"date_s:{self.year}*",
+            f"date_dt:[{self.year}-01-01T00:00:00Z TO {int(self.year)+1}-01-01T00:00:00Z}}",
         ]
         docs = solr_utils.solr_query(fq)
         filepaths = defaultdict(list)
         for doc in docs:
-            filepaths[doc["date_s"]].append(doc["transformation_file_path_s"])
+            filepaths[doc["date_dt"]].append(doc["transformation_file_path_s"])
 
             # Update JSON transformations list
             fq = [
@@ -203,10 +174,10 @@ class Aggregation(Dataset):
             "success_b:True",
             f'grid_name_s:{self.grid["grid_name_s"]}',
             f"field_s:{self.field.name}",
-            f"date_s:{self.year}*",
+            f"date_dt:[{self.year}-01-01T00:00:00Z TO {int(self.year)+1}-01-01T00:00:00Z}}",
         ]
         docs = solr_utils.solr_query(fq)
-        doc_dates = sorted([doc["date_s"][:10] for doc in docs])
+        doc_dates = sorted([doc["date_dt"][:10] for doc in docs])
 
         data_time_scale = self.ds_meta.get("data_time_scale_s")
 
@@ -306,6 +277,7 @@ class Aggregation(Dataset):
 
     def aggregate(self):
         aggregation_successes = True
+        aggregation_started_dt = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         # Construct list of dates corresponding to data time scale
         grid_path = self.grid["grid_path_s"]
         grid_name = self.grid["grid_name_s"]
@@ -476,17 +448,24 @@ class Aggregation(Dataset):
                     "set": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
                 },
                 "aggregation_version_s": {"set": self.version},
+                "aggregation_success_b": {"set": success},
+                "aggregation_started_dt": {"set": aggregation_started_dt},
+                "year_i": {"set": int(self.year)},
+                "error_message_s": {"set": "" if success else "Aggregation failed"},
             }
         else:
             update_doc = {
                 "type_s": "aggregation",
                 "dataset_s": self.ds_name,
                 "year_s": self.year,
+                "year_i": int(self.year),
                 "grid_name_s": grid_name,
                 "field_s": self.field.name,
                 "aggregation_time_dt": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "aggregation_started_dt": aggregation_started_dt,
                 "aggregation_success_b": success,
                 "aggregation_version_s": self.version,
+                "error_message_s": "" if success else "Aggregation failed",
             }
 
         # Update file paths according to the data time scale and do monthly aggregation config field

--- a/ecco_pipeline/aggregations/aggregation_factory.py
+++ b/ecco_pipeline/aggregations/aggregation_factory.py
@@ -223,18 +223,22 @@ class AgJobFactory(baseclasses.Dataset):
                     # If aggregation was previously done compare transformation time with aggregation time
                     if aggregation_docs:
                         agg_time = aggregation_docs[0]["aggregation_time_dt"]
+                        needs_reaggregate = False
                         for t in transformation_docs:
                             if t["date_dt"][:4] != year:
                                 continue
                             if t["transformation_completed_dt"] > agg_time:
                                 years_to_aggregate.append(year)
+                                needs_reaggregate = True
                                 break
+                        if not needs_reaggregate:
+                            self._ensure_provenance(grid, field, year)
                     else:
                         year_tx_docs = [t for t in transformation_docs if t["date_dt"][:4] == year]
                         if self.need_to_aggregate(grid_name, field, year, year_tx_docs):
                             years_to_aggregate.append(year)
                         else:
-                            self.reconstruct_agg_solr_doc(grid_name, field, year)
+                            self.reconstruct_agg_solr_doc(grid, field, year)
                 all_jobs.extend(
                     [
                         Aggregation(self.config, grid, year, field)
@@ -278,12 +282,14 @@ class AgJobFactory(baseclasses.Dataset):
 
         return False
 
-    def reconstruct_agg_solr_doc(self, grid_name: str, field, year: str) -> None:
+    def reconstruct_agg_solr_doc(self, grid: dict, field, year: str) -> None:
         """
         Creates a Solr aggregation doc from existing output files when the doc is
         missing but processing was determined to be unnecessary.  Mirrors the fields
-        written by Aggregation.aggregate().
+        written by Aggregation.aggregate().  Also generates the provenance JSON if
+        it is absent.
         """
+        grid_name = grid["grid_name_s"]
         data_time_scale = self.data_time_scale
         shortest_filename = f"{self.ds_name}_{grid_name}_{data_time_scale.upper()}_{field.name}_{year}"
         monthly_filename = f"{self.ds_name}_{grid_name}_MONTHLY_{field.name}_{year}"
@@ -346,3 +352,35 @@ class AgJobFactory(baseclasses.Dataset):
             logger.warning(
                 f"Failed to reconstruct Solr aggregation doc for {self.ds_name} {grid_name} {field.name} {year}"
             )
+
+        self._ensure_provenance(grid, field, year)
+
+    def _ensure_provenance(self, grid: dict, field, year: str) -> None:
+        """
+        Generate the provenance JSON for a grid/field/year if it does not already exist.
+        Called in all skip paths so that provenance files are always present even when
+        aggregation itself is not re-run (e.g. after a Solr wipe and repopulation).
+        """
+        grid_name = grid["grid_name_s"]
+        json_filename = f"{self.ds_name}_{field.name}_{grid_name}_{year}_descendants.json"
+        json_path = os.path.join(
+            OUTPUT_DIR,
+            self.ds_name,
+            "transformed_products",
+            grid_name,
+            "aggregated",
+            field.name,
+            json_filename,
+        )
+        if not os.path.exists(json_path):
+            logger.debug(
+                f"Provenance file missing for {self.ds_name} {grid_name} {field.name} {year}, generating."
+            )
+            try:
+                agg = Aggregation(self.config, grid, year, field)
+                agg.get_filepaths()
+                agg.generate_provenance(grid_name, {}, True)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to generate provenance for {self.ds_name} {grid_name} {field.name} {year}: {e}"
+                )

--- a/ecco_pipeline/aggregations/aggregation_factory.py
+++ b/ecco_pipeline/aggregations/aggregation_factory.py
@@ -115,6 +115,7 @@ class AgJobFactory(baseclasses.Dataset):
                 "id": ds_metadata["id"],
                 "aggregation_version_s": {"set": str(self.a_version)},
                 "aggregation_status_s": {"set": aggregation_status},
+                "last_aggregation_dt": {"set": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")},
             }
         ]
 
@@ -203,7 +204,7 @@ class AgJobFactory(baseclasses.Dataset):
                 ]
                 transformation_docs = solr_utils.solr_query(fq)
                 transformation_years = list(
-                    set([t["date_s"][:4] for t in transformation_docs])
+                    set([t["date_dt"][:4] for t in transformation_docs])
                 )
                 transformation_years.sort()
                 years_to_aggregate = []
@@ -223,13 +224,13 @@ class AgJobFactory(baseclasses.Dataset):
                     if aggregation_docs:
                         agg_time = aggregation_docs[0]["aggregation_time_dt"]
                         for t in transformation_docs:
-                            if t["date_s"][:4] != year:
+                            if t["date_dt"][:4] != year:
                                 continue
                             if t["transformation_completed_dt"] > agg_time:
                                 years_to_aggregate.append(year)
                                 break
                     else:
-                        year_tx_docs = [t for t in transformation_docs if t["date_s"][:4] == year]
+                        year_tx_docs = [t for t in transformation_docs if t["date_dt"][:4] == year]
                         if self.need_to_aggregate(grid_name, field, year, year_tx_docs):
                             years_to_aggregate.append(year)
                         else:
@@ -305,11 +306,13 @@ class AgJobFactory(baseclasses.Dataset):
             "type_s": "aggregation",
             "dataset_s": self.ds_name,
             "year_s": year,
+            "year_i": int(year),
             "grid_name_s": grid_name,
             "field_s": field.name,
             "aggregation_time_dt": agg_time,
             "aggregation_success_b": True,
             "aggregation_version_s": str(self.a_version),
+            "error_message_s": "",
         }
 
         if data_time_scale == "daily":

--- a/ecco_pipeline/harvesters/catds_harvester.py
+++ b/ecco_pipeline/harvesters/catds_harvester.py
@@ -45,21 +45,25 @@ class CATDS_Harvester(Harvester):
                 return []
 
             success = True
+            error_message = ""
             granule = Granule(
                 self.ds_name, local_fp, dt, catds_granule.mod_time, catds_granule.url
             )
 
+            download_duration = 0
             if self.need_to_download(granule):
                 logger.info(f"Downloading {filename} to {local_fp}")
+                download_start = datetime.utcnow()
                 try:
                     self.dl_file(catds_granule.url, local_fp)
-                except Exception:
+                except Exception as e:
                     success = False
+                    error_message = str(e)
+                download_duration = int((datetime.utcnow() - download_start).total_seconds())
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success)
-            granule.update_descendant(self.descendant_docs, success)
+            granule.update_item(self.solr_docs, success, error_message, download_duration)
             return granule.get_solr_docs()
 
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -84,7 +88,7 @@ class CATDS_Harvester(Harvester):
 def harvester(config: dict) -> str:
     """
     Uses CMR search to find granules within date range given in harvester_config.yaml.
-    Creates (or updates) Solr entries for dataset, harvested granule, and descendants.
+    Creates (or updates) Solr entries for dataset and harvested granules.
     """
 
     harvester = CATDS_Harvester(config)

--- a/ecco_pipeline/harvesters/cmr_harvester.py
+++ b/ecco_pipeline/harvesters/cmr_harvester.py
@@ -66,21 +66,25 @@ class CMR_Harvester(Harvester):
                 return []
 
             success = True
+            error_message = ""
             granule = Granule(
                 self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
             )
 
+            download_duration = 0
             if self.need_to_download(granule):
                 logger.info(f"Downloading {filename} to {local_fp}")
+                download_start = datetime.utcnow()
                 try:
                     self.dl_file(cmr_granule.url, local_fp)
-                except Exception:
+                except Exception as e:
                     success = False
+                    error_message = str(e)
+                download_duration = int((datetime.utcnow() - download_start).total_seconds())
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success)
-            granule.update_descendant(self.descendant_docs, success)
+            granule.update_item(self.solr_docs, success, error_message, download_duration)
             return granule.get_solr_docs()
 
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -198,7 +202,6 @@ class CMR_Harvester(Harvester):
                         cmr_granule.url,
                     )
                     daily_granule.update_item(self.solr_docs, success)
-                    daily_granule.update_descendant(self.descendant_docs, success)
                     solr_docs.extend(daily_granule.get_solr_docs())
                 except Exception:
                     logger.debug(
@@ -238,6 +241,7 @@ class CMR_Harvester(Harvester):
             local_fp = os.path.join(self.target_dir, filename)
             os.makedirs(self.target_dir, exist_ok=True)
 
+            download_start = datetime.utcnow()
             if (
                 not os.path.exists(local_fp)
                 or datetime.fromtimestamp(os.path.getmtime(local_fp)) < cmr_granule.mod_time
@@ -248,6 +252,7 @@ class CMR_Harvester(Harvester):
             else:
                 logger.info("File up to date. Slicing to ensure entries in Solr...")
                 downloaded = False
+            download_duration = int((datetime.utcnow() - download_start).total_seconds())
 
             ds = xr.open_dataset(local_fp, decode_times=True)
 
@@ -306,8 +311,7 @@ class CMR_Harvester(Harvester):
                     cmr_granule.mod_time,
                     cmr_granule.url,
                 )
-                monthly_granule.update_item(self.solr_docs, success)
-                monthly_granule.update_descendant(self.descendant_docs, success)
+                monthly_granule.update_item(self.solr_docs, success, download_duration=download_duration)
                 solr_docs.extend(monthly_granule.get_solr_docs())
             return solr_docs
 
@@ -372,21 +376,25 @@ class CMR_Harvester(Harvester):
                 return []
 
             success = True
+            error_message = ""
             granule = Granule(
                 self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
             )
 
+            download_duration = 0
             if self.need_to_download(granule):
                 logger.info(f"Downloading {filename} to {local_fp}")
+                download_start = datetime.utcnow()
                 try:
                     self.dl_file(cmr_granule.url, local_fp)
-                except Exception:
+                except Exception as e:
                     success = False
+                    error_message = str(e)
+                download_duration = int((datetime.utcnow() - download_start).total_seconds())
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success)
-            granule.update_descendant(self.descendant_docs, success)
+            granule.update_item(self.solr_docs, success, error_message, download_duration)
             return granule.get_solr_docs()
 
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -466,21 +474,25 @@ class CMR_Harvester(Harvester):
                 return []
 
             success = True
+            error_message = ""
             granule = Granule(
                 self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
             )
 
+            download_duration = 0
             if self.need_to_download(granule):
                 logger.info(f"Downloading {filename} to {local_fp}")
+                download_start = datetime.utcnow()
                 try:
                     self.dl_file(cmr_granule.url, local_fp)
-                except Exception:
+                except Exception as e:
                     success = False
+                    error_message = str(e)
+                download_duration = int((datetime.utcnow() - download_start).total_seconds())
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success)
-            granule.update_descendant(self.descendant_docs, success)
+            granule.update_item(self.solr_docs, success, error_message, download_duration)
             return granule.get_solr_docs()
 
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -495,7 +507,7 @@ class CMR_Harvester(Harvester):
 def harvester(config: dict) -> str:
     """
     Uses CMR search to find granules within date range given in harvester_config.yaml.
-    Creates (or updates) Solr entries for dataset, harvested granule, and descendants.
+    Creates (or updates) Solr entries for dataset and harvested granules.
     """
 
     harvester = CMR_Harvester(config)

--- a/ecco_pipeline/harvesters/harvesterclasses.py
+++ b/ecco_pipeline/harvesters/harvesterclasses.py
@@ -25,30 +25,19 @@ class Granule:
         self.modified_time = modified_time
         self.url = url
         self.gen_granule_doc()
-        self.gen_descendant_doc()
 
     def gen_granule_doc(self):
         item = {}
         item["type_s"] = "granule"
-        item["date_s"] = datetime.strftime(self.datetime, "%Y-%m-%dT00:00:00Z")
+        item["date_dt"] = datetime.strftime(self.datetime, "%Y-%m-%dT00:00:00Z")
         item["dataset_s"] = self.ds_name
         item["filename_s"] = self.filename
         item["source_s"] = self.url
         item["modified_time_dt"] = self.modified_time.strftime("%Y-%m-%dT00:00:00Z")
+        item["error_message_s"] = ""
         self.solr_item = item
 
-    def gen_descendant_doc(self):
-        descendant_item = {}
-        descendant_item["type_s"] = "descendants"
-        descendant_item["date_s"] = datetime.strftime(
-            self.datetime, "%Y-%m-%dT00:00:00Z"
-        )
-        descendant_item["dataset_s"] = self.ds_name
-        descendant_item["filename_s"] = self.filename
-        descendant_item["source_s"] = self.url
-        self.descendant_item = descendant_item
-
-    def update_item(self, solr_docs, success):
+    def update_item(self, solr_docs, success, error_message="", download_duration=0):
         if self.filename in solr_docs.keys():
             self.solr_item["id"] = solr_docs[self.filename]["id"]
 
@@ -58,28 +47,19 @@ class Granule:
             self.solr_item["pre_transformation_file_path_s"] = self.local_fp
             self.solr_item["harvest_success_b"] = True
             self.solr_item["file_size_l"] = os.path.getsize(self.local_fp)
+            self.solr_item["error_message_s"] = ""
         else:
             self.solr_item["harvest_success_b"] = False
             self.solr_item["pre_transformation_file_path_s"] = ""
             self.solr_item["file_size_l"] = 0
+            self.solr_item["error_message_s"] = error_message
         self.solr_item["download_time_dt"] = datetime.utcnow().strftime(
             "%Y-%m-%dT00:00:00Z"
         )
-
-    def update_descendant(self, descendants_docs, success):
-        # Update Solr entry using id if it exists
-        key = self.descendant_item["filename_s"]
-
-        if key in descendants_docs.keys():
-            self.descendant_item["id"] = descendants_docs[key]["id"]
-
-        self.descendant_item["harvest_success_b"] = success
-        self.descendant_item["pre_transformation_file_path_s"] = self.solr_item.get(
-            "pre_transformation_file_path_s"
-        )
+        self.solr_item["download_duration_i"] = download_duration
 
     def get_solr_docs(self):
-        return [self.solr_item, self.descendant_item]
+        return [self.solr_item]
 
 
 class Harvester(Dataset):
@@ -96,7 +76,7 @@ class Harvester(Dataset):
         self.ensure_target_dir()
         solr_utils.clean_solr(config)
 
-        self.solr_docs, self.descendant_docs = self.get_solr_docs()
+        self.solr_docs = self.get_solr_docs()
         self.config: dict = config
 
     def _harvester_parsing(self, config: dict):
@@ -118,9 +98,8 @@ class Harvester(Dataset):
     def ensure_target_dir(self):
         os.makedirs(self.target_dir, exist_ok=True)
 
-    def get_solr_docs(self) -> list:
+    def get_solr_docs(self) -> dict:
         docs = {}
-        descendants_docs = {}
 
         # Query for existing harvested docs — only fetch fields needed for
         # check_update (harvest_success_b, download_time_dt) and upserts (id)
@@ -131,13 +110,7 @@ class Harvester(Dataset):
         for doc in harvested_docs:
             docs[doc["filename_s"]] = doc
 
-        # Query for existing descendants docs — only id needed for upserts
-        fq = ["type_s:descendants", f"dataset_s:{self.ds_name}"]
-        existing_descendants_docs = solr_utils.solr_query(fq, fl="id,filename_s")
-        for doc in existing_descendants_docs:
-            descendants_docs[doc["filename_s"]] = doc
-
-        return docs, descendants_docs
+        return docs
 
     def make_ds_doc(self, source: str, chk_time: str):
         ds_meta = {}
@@ -158,6 +131,8 @@ class Harvester(Dataset):
             "original_dataset_reference"
         ]
         ds_meta["original_dataset_doi_s"] = self.og_ds_metadata["original_dataset_doi"]
+        ds_meta["harvester_type_s"] = self.harvester_type
+        ds_meta["t_version_f"] = self.t_version
         return ds_meta
 
     def check_update(self, filename, mod_time):
@@ -208,13 +183,21 @@ class Harvester(Dataset):
                 "type_s:granule",
                 "harvest_success_b:true",
             ]
-            dates_query = solr_utils.solr_query(fq, fl="date_s")
-            dates = [x["date_s"] for x in dates_query]
+            dates_query = solr_utils.solr_query(fq, fl="date_dt")
+            dates = [x["date_dt"] for x in dates_query]
+
+            # Granule counts for dashboard
+            fq_base = ["type_s:granule", f"dataset_s:{self.ds_name}"]
+            n_failed = solr_utils.solr_count(fq_base + ["harvest_success_b:false"])
+            n_success = solr_utils.solr_count(fq_base + ["harvest_success_b:true"])
 
             # Build update document body
             ds_meta = {}
             ds_meta["id"] = dataset_metadata["id"]
             ds_meta["last_checked_dt"] = {"set": check_time}
+            ds_meta["n_granules_i"] = {"set": n_failed + n_success}
+            ds_meta["n_granules_success_i"] = {"set": n_success}
+            ds_meta["n_granules_failed_i"] = {"set": n_failed}
             if dates:
                 ds_meta["start_date_dt"] = {"set": min(dates)}
                 ds_meta["end_date_dt"] = {"set": max(dates)}
@@ -244,9 +227,9 @@ class Harvester(Dataset):
                     for doc in self.updated_solr_docs
                     if "download_time_dt" in doc.keys()
                 ]
-                dl_items = sorted(dl_solr_docs, key=lambda d: d["date_s"])
-                ds_meta["start_date_dt"] = dl_items[0]["date_s"]
-                ds_meta["end_date_dt"] = dl_items[-1]["date_s"]
+                dl_items = sorted(dl_solr_docs, key=lambda d: d["date_dt"])
+                ds_meta["start_date_dt"] = dl_items[0]["date_dt"]
+                ds_meta["end_date_dt"] = dl_items[-1]["date_dt"]
                 ds_meta["last_download_dt"] = sorted(
                     dl_solr_docs, key=lambda d: d["download_time_dt"]
                 )[-1]["download_time_dt"]

--- a/ecco_pipeline/harvesters/nsidc_harvester.py
+++ b/ecco_pipeline/harvesters/nsidc_harvester.py
@@ -44,21 +44,25 @@ class NSIDC_Harvester(Harvester):
                 return []
 
             success = True
+            error_message = ""
             granule = Granule(
                 self.ds_name, local_fp, dt, nsidc_granule.mod_time, nsidc_granule.url
             )
 
+            download_duration = 0
             if self.need_to_download(granule):
                 logger.info(f"Downloading {filename} to {local_fp}")
+                download_start = datetime.utcnow()
                 try:
                     self.dl_file(nsidc_granule.url, local_fp)
-                except Exception:
+                except Exception as e:
                     success = False
+                    error_message = str(e)
+                download_duration = int((datetime.utcnow() - download_start).total_seconds())
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success)
-            granule.update_descendant(self.descendant_docs, success)
+            granule.update_item(self.solr_docs, success, error_message, download_duration)
             return granule.get_solr_docs()
 
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -83,7 +87,7 @@ class NSIDC_Harvester(Harvester):
 def harvester(config: dict) -> str:
     """
     Uses CMR search to find granules within date range given in harvester_config.yaml.
-    Creates (or updates) Solr entries for dataset, harvested granule, and descendants.
+    Creates (or updates) Solr entries for dataset and harvested granules.
     """
 
     harvester = NSIDC_Harvester(config)

--- a/ecco_pipeline/harvesters/osisaf_harvester.py
+++ b/ecco_pipeline/harvesters/osisaf_harvester.py
@@ -54,21 +54,25 @@ class OSISAF_Harvester(Harvester):
                 return []
 
             success = True
+            error_message = ""
             granule = Granule(
                 self.ds_name, local_fp, dt, osisaf_granule.mod_time, osisaf_granule.url
             )
 
+            download_duration = 0
             if self.need_to_download(granule):
                 logger.info(f"Downloading {filename} to {local_fp}")
+                download_start = datetime.utcnow()
                 try:
                     self.dl_file(osisaf_granule.url, local_fp)
-                except Exception:
+                except Exception as e:
                     success = False
+                    error_message = str(e)
+                download_duration = int((datetime.utcnow() - download_start).total_seconds())
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success)
-            granule.update_descendant(self.descendant_docs, success)
+            granule.update_item(self.solr_docs, success, error_message, download_duration)
             return granule.get_solr_docs()
 
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -96,7 +100,7 @@ class OSISAF_Harvester(Harvester):
 def harvester(config: dict) -> str:
     """
     Uses CMR search to find granules within date range given in harvester_config.yaml.
-    Creates (or updates) Solr entries for dataset, harvested granule, and descendants.
+    Creates (or updates) Solr entries for dataset and harvested granules.
     """
 
     harvester = OSISAF_Harvester(config)

--- a/ecco_pipeline/tests/aggregations/test_aggregation.py
+++ b/ecco_pipeline/tests/aggregations/test_aggregation.py
@@ -287,7 +287,7 @@ class AggregationGetFilepathsTestCase(unittest.TestCase):
             [{"start_date_dt": "2020-01-01T00:00:00Z"}],
             [
                 {
-                    "date_s": "2020-01-15T00:00:00Z",
+                    "date_dt": "2020-01-15T00:00:00Z",
                     "transformation_file_path_s": "/path/to/file1.nc",
                     "pre_transformation_file_path_s": "/path/to/pre1.nc",
                 }
@@ -313,12 +313,12 @@ class AggregationGetFilepathsTestCase(unittest.TestCase):
             [{"start_date_dt": "2020-01-01T00:00:00Z"}],
             [
                 {
-                    "date_s": "2020-01-15T00:00:00Z",
+                    "date_dt": "2020-01-15T00:00:00Z",
                     "transformation_file_path_s": "/path/to/asc.nc",
                     "pre_transformation_file_path_s": "/path/to/pre_asc.nc",
                 },
                 {
-                    "date_s": "2020-01-15T00:00:00Z",
+                    "date_dt": "2020-01-15T00:00:00Z",
                     "transformation_file_path_s": "/path/to/desc.nc",
                     "pre_transformation_file_path_s": "/path/to/pre_desc.nc",
                 },
@@ -343,7 +343,7 @@ class AggregationGetFilepathsTestCase(unittest.TestCase):
             [{"start_date_dt": "2020-01-01T00:00:00Z"}],
             [
                 {
-                    "date_s": "2020-01-15T00:00:00Z",
+                    "date_dt": "2020-01-15T00:00:00Z",
                     "transformation_file_path_s": "/path/to/file1.nc",
                     "pre_transformation_file_path_s": "/path/to/pre1.nc",
                 }
@@ -501,7 +501,7 @@ class AggregationGetMissingDatesTestCase(unittest.TestCase):
         mock_query.side_effect = [
             [{"start_date_dt": "2020-01-01T00:00:00Z", "data_time_scale_s": "daily"}],
             [
-                {"date_s": f"2020-{m:02d}-{d:02d}T00:00:00Z"}
+                {"date_dt": f"2020-{m:02d}-{d:02d}T00:00:00Z"}
                 for m in range(1, 13)
                 for d in range(1, 32)
                 if m in [1, 3, 5, 7, 8, 10, 12] or d <= 30
@@ -524,10 +524,10 @@ class AggregationGetMissingDatesTestCase(unittest.TestCase):
         mock_query.side_effect = [
             [{"start_date_dt": "2020-01-01T00:00:00Z", "data_time_scale_s": "daily"}],
             [
-                {"date_s": "2020-01-01T00:00:00Z"},
-                {"date_s": "2020-01-02T00:00:00Z"},
+                {"date_dt": "2020-01-01T00:00:00Z"},
+                {"date_dt": "2020-01-02T00:00:00Z"},
                 # 2020-01-03 is missing
-                {"date_s": "2020-01-04T00:00:00Z"},
+                {"date_dt": "2020-01-04T00:00:00Z"},
             ],
         ]
 
@@ -546,10 +546,10 @@ class AggregationGetMissingDatesTestCase(unittest.TestCase):
         mock_query.side_effect = [
             [{"start_date_dt": "2020-01-01T00:00:00Z", "data_time_scale_s": "monthly"}],
             [
-                {"date_s": "2020-01-01T00:00:00Z"},
-                {"date_s": "2020-02-01T00:00:00Z"},
+                {"date_dt": "2020-01-01T00:00:00Z"},
+                {"date_dt": "2020-02-01T00:00:00Z"},
                 # March missing
-                {"date_s": "2020-04-01T00:00:00Z"},
+                {"date_dt": "2020-04-01T00:00:00Z"},
             ],
         ]
 
@@ -568,8 +568,8 @@ class AggregationGetMissingDatesTestCase(unittest.TestCase):
         mock_query.side_effect = [
             [{"start_date_dt": "2020-01-01T00:00:00Z", "data_time_scale_s": "monthly"}],
             [
-                {"date_s": "2020-01-01T00:00:00Z"},
-                {"date_s": "2020-02-03T00:00:00Z"},  # Within tolerance of 2020-02-01
+                {"date_dt": "2020-01-01T00:00:00Z"},
+                {"date_dt": "2020-02-03T00:00:00Z"},  # Within tolerance of 2020-02-01
             ],
         ]
 
@@ -719,50 +719,13 @@ class AggregationGenerateProvenanceTestCase(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open)
     @patch("aggregations.aggregation.solr_utils.solr_update")
     @patch("aggregations.aggregation.solr_utils.solr_query")
-    def test_generate_provenance_updates_existing_descendants(self, mock_query, mock_update, mock_file):
-        """Test updating existing descendants documents."""
-        # First call for ds_meta, second for descendants, third for aggregation docs
-        mock_query.side_effect = [
-            [{"start_date_dt": "2020-01-01T00:00:00Z"}],
-            [{"id": "descendant1", "date_s": "2020-01-15T00:00:00Z"}],  # Existing descendants
-            [{"id": "agg1"}],  # Aggregation docs
-        ]
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_update.return_value = mock_response
-
-        config = self.get_base_config()
-        field = MagicMock()
-        field.name = "ssha"
-        agg = Aggregation(config, self.get_mock_grid(), "2020", field)
-
-        solr_paths = {
-            "daily_bin": "/path/to/daily.bin",
-            "daily_netCDF": "/path/to/daily.nc",
-        }
-
-        agg.generate_provenance("TEST_GRID", solr_paths, True)
-
-        # Check that update was called
-        mock_update.assert_called_once()
-        update_body = mock_update.call_args[0][0]
-        self.assertEqual(update_body[0]["id"], "descendant1")
-
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("aggregations.aggregation.solr_utils.solr_update")
-    @patch("aggregations.aggregation.solr_utils.solr_query")
     def test_generate_provenance_exports_json(self, mock_query, mock_update, mock_file):
-        """Test that JSON file is exported."""
+        """Test that JSON file is exported with correct content and no Solr update."""
+        # Two queries: ds_meta (in __init__) and aggregation docs
         mock_query.side_effect = [
             [{"start_date_dt": "2020-01-01T00:00:00Z", "dataset_s": "TEST_DATASET"}],
-            [],  # No existing descendants
-            [{"id": "agg1"}],  # Aggregation docs
+            [{"id": "agg1", "aggregation_success_b": True}],  # Aggregation docs
         ]
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_update.return_value = mock_response
 
         config = self.get_base_config()
         field = MagicMock()
@@ -776,8 +739,15 @@ class AggregationGenerateProvenanceTestCase(unittest.TestCase):
 
         agg.generate_provenance("TEST_GRID", solr_paths, True)
 
-        # Check that file was opened for writing
+        # JSON file should be written; no Solr update (descendants removed)
         self.assertTrue(mock_file.called)
+        mock_update.assert_not_called()
+
+        # Verify JSON content
+        written = json.loads(mock_file().write.call_args[0][0])
+        self.assertEqual(written["dataset"]["dataset_s"], "TEST_DATASET")
+        self.assertEqual(written["aggregation"][0]["id"], "agg1")
+        self.assertIn("transformations", written)
 
 
 if __name__ == "__main__":

--- a/ecco_pipeline/tests/aggregations/test_aggregation_factory.py
+++ b/ecco_pipeline/tests/aggregations/test_aggregation_factory.py
@@ -285,6 +285,7 @@ class AgJobFactoryMakeJobsTestCase(unittest.TestCase):
             "start": "20200101T00:00:00Z",
             "end": "20201231T00:00:00Z",
             "a_version": "2.0",
+            "data_time_scale": "daily",
             "fields": [
                 {
                     "name": "ssha",
@@ -308,7 +309,7 @@ class AgJobFactoryMakeJobsTestCase(unittest.TestCase):
         mock_query.side_effect = [
             [{"grid_name_s": "GRID1"}],  # grids
             [{"start_date_dt": "2020-01-01T00:00:00Z", "aggregation_version_s": "2.0"}],  # ds_meta
-            [{"date_s": "2020-01-15T00:00:00Z"}],  # transformations
+            [{"date_dt": "2020-01-15T00:00:00Z"}],  # transformations
             [],  # no existing aggregation
         ]
 
@@ -331,7 +332,7 @@ class AgJobFactoryMakeJobsTestCase(unittest.TestCase):
             [{"start_date_dt": "2020-01-01T00:00:00Z", "aggregation_version_s": "2.0"}],  # ds_meta
             [  # transformations
                 {
-                    "date_s": "2020-01-15T00:00:00Z",
+                    "date_dt": "2020-01-15T00:00:00Z",
                     "transformation_completed_dt": "2020-01-16T10:00:00Z",
                 }
             ],
@@ -362,7 +363,7 @@ class AgJobFactoryMakeJobsTestCase(unittest.TestCase):
             [{"start_date_dt": "2020-01-01T00:00:00Z", "aggregation_version_s": "2.0"}],  # ds_meta
             [  # transformations
                 {
-                    "date_s": "2020-01-15T00:00:00Z",
+                    "date_dt": "2020-01-15T00:00:00Z",
                     "transformation_completed_dt": "2020-01-17T10:00:00Z",
                 }
             ],
@@ -707,6 +708,7 @@ class AgJobFactoryPipelineCleanupTestCase(unittest.TestCase):
             "start": "20200101T00:00:00Z",
             "end": "20201231T00:00:00Z",
             "a_version": "1.0",
+            "data_time_scale": "daily",
             "fields": [
                 {
                     "name": "ssha",
@@ -738,7 +740,7 @@ class AgJobFactoryPipelineCleanupTestCase(unittest.TestCase):
                     "aggregation_version_s": "1.0",
                 }
             ],  # dataset metadata (get_jobs during init)
-            [{"date_s": "2020-01-15T00:00:00Z"}],  # Transformations query (make_jobs)
+            [{"date_dt": "2020-01-15T00:00:00Z"}],  # Transformations query (make_jobs)
             [],  # Existing aggregations query
             [{"id": "agg1"}],  # successful aggregations (get_agg_status call in pipeline_cleanup)
             [],  # no failed aggregations (get_agg_status call in pipeline_cleanup)

--- a/ecco_pipeline/tests/harvesters/test_catds_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_catds_harvester.py
@@ -105,7 +105,7 @@ class CATDSHarvesterTestCase(unittest.TestCase):
                 h.fetch()
 
                 mock_requests.assert_called_once()
-                self.assertEqual(len(h.updated_solr_docs), 2)
+                self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
     @patch("harvesters.catds_harvester.requests.get")
     def test_fetch_skips_out_of_range_dates(self, mock_requests, mock_search, mock_clean, mock_query):
@@ -178,8 +178,8 @@ class CATDSHarvesterTestCase(unittest.TestCase):
                 h.fetch()
 
                 self.assertEqual(mock_requests.call_count, 3)
-                # 3 granules * 2 docs (granule + descendant) = 6
-                self.assertEqual(len(h.updated_solr_docs), 6)
+                # 3 granules * 1 doc each = 3
+                self.assertEqual(len(h.updated_solr_docs), 3)
 
 
 @patch("harvesters.harvesterclasses.solr_utils.solr_query")

--- a/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
@@ -127,7 +127,7 @@ class CMRHarvesterTestCase(unittest.TestCase):
 
                 # Verify download occurred
                 mock_requests.assert_called_once()
-                self.assertEqual(len(h.updated_solr_docs), 2)  # granule + descendant
+                self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
     @patch("harvesters.cmr_harvester.requests.get")
     def test_fetch_skips_nrt_files(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
@@ -264,8 +264,8 @@ class CMRHarvesterTestCase(unittest.TestCase):
                 h.fetch()
 
                 self.assertEqual(mock_requests.call_count, 3)
-                # 3 granules * 2 docs = 6
-                self.assertEqual(len(h.updated_solr_docs), 6)
+                # 3 granules * 1 doc each = 3
+                self.assertEqual(len(h.updated_solr_docs), 3)
 
     @patch("harvesters.cmr_harvester.time.sleep")
     @patch("harvesters.cmr_harvester.requests.get")

--- a/ecco_pipeline/tests/harvesters/test_harvesterclasses.py
+++ b/ecco_pipeline/tests/harvesters/test_harvesterclasses.py
@@ -52,22 +52,7 @@ class GranuleTestCase(unittest.TestCase):
         self.assertEqual(granule.solr_item["dataset_s"], self.ds_name)
         self.assertEqual(granule.solr_item["filename_s"], "test_file_20200101.nc")
         self.assertEqual(granule.solr_item["source_s"], self.url)
-        self.assertEqual(granule.solr_item["date_s"], "2020-01-01T00:00:00Z")
-
-    def test_gen_descendant_doc(self):
-        """Test that descendant Solr document is generated correctly."""
-        granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
-        )
-
-        self.assertEqual(granule.descendant_item["type_s"], "descendants")
-        self.assertEqual(granule.descendant_item["dataset_s"], self.ds_name)
-        self.assertEqual(granule.descendant_item["filename_s"], "test_file_20200101.nc")
-        self.assertEqual(granule.descendant_item["source_s"], self.url)
+        self.assertEqual(granule.solr_item["date_dt"], "2020-01-01T00:00:00Z")
 
     @patch("harvesters.harvesterclasses.file_utils.md5")
     def test_update_item_success(self, mock_md5):
@@ -133,30 +118,8 @@ class GranuleTestCase(unittest.TestCase):
 
         self.assertEqual(granule.solr_item["id"], "existing-solr-id-123")
 
-    def test_update_descendant_success(self):
-        """Test update_descendant with successful status."""
-        granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
-        )
-
-        # Pre-populate solr_item with path
-        granule.solr_item["pre_transformation_file_path_s"] = self.local_fp
-
-        descendants_docs = {}
-        granule.update_descendant(descendants_docs, success=True)
-
-        self.assertTrue(granule.descendant_item["harvest_success_b"])
-        self.assertEqual(
-            granule.descendant_item["pre_transformation_file_path_s"],
-            self.local_fp
-        )
-
     def test_get_solr_docs(self):
-        """Test get_solr_docs returns both documents."""
+        """Test get_solr_docs returns one granule document."""
         granule = Granule(
             self.ds_name,
             self.local_fp,
@@ -167,9 +130,8 @@ class GranuleTestCase(unittest.TestCase):
 
         docs = granule.get_solr_docs()
 
-        self.assertEqual(len(docs), 2)
+        self.assertEqual(len(docs), 1)
         self.assertEqual(docs[0]["type_s"], "granule")
-        self.assertEqual(docs[1]["type_s"], "descendants")
 
 
 @patch("harvesters.harvesterclasses.solr_utils.solr_query")
@@ -402,6 +364,8 @@ class HarvesterTestCase(unittest.TestCase):
                 self.assertEqual(ds_doc["dataset_s"], "TEST_DATASET")
                 self.assertEqual(ds_doc["short_name_s"], "TEST")
                 self.assertEqual(ds_doc["data_time_scale_s"], "daily")
+                self.assertEqual(ds_doc["harvester_type_s"], "nsidc")
+                self.assertEqual(ds_doc["t_version_f"], 1.0)
 
     @patch("harvesters.harvesterclasses.solr_utils.solr_update")
     def test_post_fetch_no_updates(self, mock_update, mock_clean, mock_query):
@@ -442,7 +406,7 @@ class HarvesterTestCase(unittest.TestCase):
                             "type_s": "granule",
                             "harvest_success_b": True,
                             "download_time_dt": "2020-01-01T00:00:00Z",
-                            "date_s": "2020-01-01T00:00:00Z"
+                            "date_dt": "2020-01-01T00:00:00Z"
                         }
                     ]
 
@@ -481,15 +445,10 @@ class HarvesterTestCase(unittest.TestCase):
                     self.assertIn("failed", status)
 
     def test_get_solr_docs_with_existing(self, mock_clean, mock_query):
-        """Test get_solr_docs retrieves existing documents."""
-        mock_query.side_effect = [
-            [
-                {"filename_s": "file1.nc", "id": "id1"},
-                {"filename_s": "file2.nc", "id": "id2"}
-            ],
-            [
-                {"filename_s": "file1.nc", "id": "desc1"}
-            ]
+        """Test get_solr_docs retrieves existing granule documents."""
+        mock_query.return_value = [
+            {"filename_s": "file1.nc", "id": "id1"},
+            {"filename_s": "file2.nc", "id": "id2"},
         ]
 
         config = self.get_mock_config()
@@ -500,7 +459,6 @@ class HarvesterTestCase(unittest.TestCase):
 
                 self.assertEqual(len(harvester.solr_docs), 2)
                 self.assertEqual(harvester.solr_docs["file1.nc"]["id"], "id1")
-                self.assertEqual(len(harvester.descendant_docs), 1)
 
 
 if __name__ == "__main__":

--- a/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
@@ -108,7 +108,7 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
 
                 # Verify download occurred
                 mock_requests.assert_called_once()
-                self.assertEqual(len(h.updated_solr_docs), 2)  # granule + descendant
+                self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
     @patch("harvesters.nsidc_harvester.requests.get")
     def test_fetch_skips_out_of_range_dates(self, mock_requests, mock_search, mock_clean, mock_query):

--- a/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
@@ -105,7 +105,7 @@ class OSISAFHarvesterTestCase(unittest.TestCase):
                 h.fetch()
 
                 mock_requests.assert_called_once()
-                self.assertEqual(len(h.updated_solr_docs), 2)
+                self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
     @patch("harvesters.osisaf_harvester.requests.get")
     def test_fetch_skips_icdrft_files(self, mock_requests, mock_search, mock_clean, mock_query):

--- a/ecco_pipeline/tests/transformations/test_transformation_factory.py
+++ b/ecco_pipeline/tests/transformations/test_transformation_factory.py
@@ -377,7 +377,7 @@ class MultiprocessTransformationTestCase(unittest.TestCase):
         mock_logging.return_value = mock_logger
 
         config = {"ds_name": "TEST"}
-        granule = {"pre_transformation_file_path_s": "/data/test.nc", "file_size_l": 1000, "date_s": "2020-01-01"}
+        granule = {"pre_transformation_file_path_s": "/data/test.nc", "file_size_l": 1000, "date_dt": "2020-01-01"}
         tx_jobs = {"grid": ["field"]}
 
         multiprocess_transformation(config, granule, tx_jobs, "INFO", "/logs")

--- a/ecco_pipeline/transformations/grid_transformation.py
+++ b/ecco_pipeline/transformations/grid_transformation.py
@@ -248,12 +248,14 @@ class Transformation(Dataset):
                 except Exception as e:
                     logger.exception(e)
 
+            error_message = ""
             if field.name in ds.data_vars:
                 try:
                     field_DA = self.perform_mapping(ds, factors, field, model_grid)
                     mapping_success = True
                 except Exception as e:
                     logger.exception(f"Transformation failed: {e}")
+                    error_message = str(e)
                     field_DA = records.make_empty_record(record_date, model_grid)
                     field_DA.attrs["long_name"] = field.long_name
                     field_DA.attrs["standard_name"] = field.standard_name
@@ -284,6 +286,7 @@ class Transformation(Dataset):
                         field_DA.attrs["valid_max"] = np.nanmax(field_DA.values)
                 except Exception as e:
                     logger.exception(f"Post-transformation failed: {e}")
+                    error_message = str(e)
                     field_DA = records.make_empty_record(record_date, model_grid)
                     field_DA.attrs["long_name"] = field.long_name
                     field_DA.attrs["standard_name"] = field.standard_name
@@ -348,7 +351,7 @@ class Transformation(Dataset):
 
             field_DS = field_DS.drop("time_start")
             field_DS = field_DS.drop("time_end")
-            field_DSs.append((field_DS, mapping_success))
+            field_DSs.append((field_DS, mapping_success, error_message))
 
         return field_DSs
 
@@ -398,8 +401,9 @@ class Transformation(Dataset):
 
                 # Initialize new transformation entry
                 transform["type_s"] = "transformation"
-                transform["date_s"] = self.date
+                transform["date_dt"] = self.date
                 transform["dataset_s"] = self.ds_name
+                transform["transformation_started_dt"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
                 transform["pre_transformation_file_path_s"] = source_file_path
                 transform["hemisphere_s"] = self.hemi.replace("_", "")
                 transform["origin_checksum_s"] = docs[0]["checksum_s"]
@@ -419,7 +423,7 @@ class Transformation(Dataset):
 def transform(source_file_path: str, tx_jobs: dict, config: dict, granule_date: str):
     """
     Performs and saves locally all remaining transformations for a given source granule
-    Updates Solr with transformation entries and updates descendants, and dataset entries
+    Updates Solr with transformation entries and dataset entries
     """
     T = Transformation(config, source_file_path, granule_date)
 
@@ -454,7 +458,7 @@ def transform(source_file_path: str, tx_jobs: dict, config: dict, granule_date: 
         # Save the output in netCDF format
         # =====================================================
         # Save each transformed granule for the current field
-        for field, (field_DS, success) in zip(fields, field_DSs):
+        for field, (field_DS, success, error_message) in zip(fields, field_DSs):
             output_filename = f"{grid_name}_{field.name}_{T.file_name}.nc"
 
             output_path = os.path.join(
@@ -497,6 +501,7 @@ def transform(source_file_path: str, tx_jobs: dict, config: dict, granule_date: 
                     "success_b": {"set": success},
                     "transformation_checksum_s": {"set": file_utils.md5(transformed_location)},
                     "transformation_version_f": {"set": T.transformation_version},
+                    "error_message_s": {"set": error_message},
                 }
             ]
 

--- a/ecco_pipeline/transformations/transformation_factory.py
+++ b/ecco_pipeline/transformations/transformation_factory.py
@@ -26,7 +26,7 @@ def multiprocess_transformation(
         print(e)
 
     granule_filepath = granule.get("pre_transformation_file_path_s")
-    granule_date = granule.get("date_s")
+    granule_date = granule.get("date_dt")
 
     # Skips granules that weren't harvested properly
     if not granule_filepath or granule.get("file_size_l") < 100:
@@ -132,6 +132,7 @@ class TxJobFactory(baseclasses.Dataset):
             {
                 "id": dataset_metadata["id"],
                 "transformation_status_s": {"set": transformation_status},
+                "last_transformation_dt": {"set": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")},
             }
         ]
 
@@ -308,7 +309,7 @@ class TxJobFactory(baseclasses.Dataset):
 
         doc = {
             "type_s": "transformation",
-            "date_s": granule["date_s"],
+            "date_dt": granule["date_dt"],
             "dataset_s": self.ds_name,
             "pre_transformation_file_path_s": granule.get("pre_transformation_file_path_s"),
             "hemisphere_s": hemi,
@@ -316,12 +317,14 @@ class TxJobFactory(baseclasses.Dataset):
             "grid_name_s": grid_name,
             "field_s": field.name,
             "transformation_in_progress_b": False,
+            "transformation_started_dt": completed_dt,
             "success_b": True,
             "filename_s": output_filename,
             "transformation_file_path_s": output_path,
             "transformation_completed_dt": completed_dt,
             "transformation_checksum_s": file_utils.md5(output_path),
             "transformation_version_f": self.t_version,
+            "error_message_s": "",
         }
 
         r = solr_utils.solr_update([doc], r=True)

--- a/ecco_pipeline/utils/pipeline_utils/solr_utils.py
+++ b/ecco_pipeline/utils/pipeline_utils/solr_utils.py
@@ -79,13 +79,13 @@ def check_grids():
     """
     Check if grids have been written to Solr
     """
-    if not solr_query(["type_s=grid"]):
+    if not solr_query(["type_s:grid"]):
         return True
     return False
 
 
 def validate_granules():
-    granules = solr_query(["type_s=granule"])
+    granules = solr_query(["type_s:granule"], fl="id,pre_transformation_file_path_s")
     docs_to_remove = []
 
     for granule in granules:
@@ -101,7 +101,7 @@ def validate_granules():
 
 def clean_solr(config):
     """
-    Remove harvested, transformed, and descendant entries in Solr for dates
+    Remove harvested and transformed entries in Solr for dates
     outside of config date range. Also remove related aggregations, and force
     aggregation rerun for those years.
     """
@@ -125,12 +125,12 @@ def clean_solr(config):
         dataset_metadata = dataset_metadata[0]
 
     # Remove entries earlier than config start date
-    fq = f"dataset_s:{dataset_name} AND date_s:[* TO {config_start}}}"
+    fq = f"dataset_s:{dataset_name} AND date_dt:[* TO {config_start}T00:00:00Z}}"
     url = f"{SOLR_HOST}{SOLR_COLLECTION}/update?commit=true"
     requests.post(url, json={"delete": {"query": fq}})
 
     # Remove entries later than config end date
-    fq = f"dataset_s:{dataset_name} AND date_s:{{{config_end} TO *]"
+    fq = f"dataset_s:{dataset_name} AND date_dt:{{{config_end}T00:00:00Z TO *]"
     url = f"{SOLR_HOST}{SOLR_COLLECTION}/update?commit=true"
     requests.post(url, json={"delete": {"query": fq}})
 


### PR DESCRIPTION
## Summary

  - **`date_s` → `date_dt`**: Migrated all date string fields to the `_dt` dynamic field suffix, enabling Solr date math, range queries, and validation across harvesters, transformations, aggregations, and `solr_utils`
  - **Remove `descendants` doc type**: Eliminated write-only descendants docs (they were updated by `generate_provenance` but never read back); halves Solr write volume per harvested granule
  - **Pipeline observability fields**: Added `error_message_s`, `download_duration_i`, `transformation_started_dt`, `aggregation_started_dt`, `year_i`, `harvester_type_s`, `t_version_f`, `n_granules_i/success/failed`, `last_transformation_dt`, `last_aggregation_dt` to support dashboard use cases
  - **Bug fixes**: `aggregation_success_b` was missing from the existing-doc update path (stale `false` on retry); `check_grids` and `validate_granules` used invalid `type_s=x` syntax instead of `type_s:x`

  ## Migration note

  Solr must be wiped and the pipeline re-run to repopulate with the new schema. No backfill scripts are required.

Tested on local deployment.