### PR TITLE
Fix RDEFT4 CMR harvesting: update concept ID and provider host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Version numbers follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **RDEFT4**: updated CMR concept ID to `C3205181648-NSIDC_CPRD` and provider host to `data.nsidc.earthdatacloud.nasa.gov`; the previous `NSIDC_ECS` collection no longer returns granules.
+
 ---
 
 ## [v2.0.0] — 2026-05-21 — _Architeuthis dux_

--- a/ecco_pipeline/conf/ds_configs/RDEFT4.yaml
+++ b/ecco_pipeline/conf/ds_configs/RDEFT4.yaml
@@ -5,10 +5,10 @@ end: "NOW" # yyyymmddThh:mm:ssZ for specific date or "NOW" for...now
 
 # Provider specifications
 harvester_type: cmr
-cmr_concept_id: C1431413941-NSIDC_ECS
+cmr_concept_id: C3205181648-NSIDC_CPRD
 filename_date_fmt: "%Y%m%d"
 filename_date_regex: '\d{8}'
-provider: "n5eil01u.ecs.nsidc.org"
+provider: "data.nsidc.earthdatacloud.nasa.gov"
 
 # Metadata
 data_time_scale: "monthly" # daily or monthly


### PR DESCRIPTION
## Summary

  The previous CMR concept ID for RDEFT4 (`C1431413941-NSIDC_ECS`) no longer returns granules, causing the harvester to find zero files. Updated to the current collection `C3205181648-NSIDC_CPRD`, and updated the provider host accordingly so `CMRGranule.extract_url` matches the new data links.

  ## Changes
  
  - `conf/ds_configs/RDEFT4.yaml`:
     - `cmr_concept_id`: `C1431413941-NSIDC_ECS` → `C3205181648-NSIDC_CPRD`
     - `provider`: `n5eil01u.ecs.nsidc.org` → `data.nsidc.earthdatacloud.nasa.gov`
  - `CHANGELOG.md`: Added entry under `[Unreleased]` → Bug Fixes.
  
  ## Test plan
  
  - [x] Ran RDEFT4 harvester; granules are now found and downloaded.
  - [x] Confirm Solr docs are updated as expected.