### PR TITLE
Speed up harvesting: reuse connections, batch Solr writes, raise concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Version numbers follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.
 
 ## [Unreleased]
 
+### Improvements
+
+- **Harvest throughput**: download workers now reuse a per-thread keep-alive session (skipping the per-file TCP/TLS + Earthdata Login redirect overhead), download concurrency is configurable via `HARVEST_MAX_WORKERS` (default 8), and `md5()` reads in larger chunks. A test collection went from ~70 to ~660 granules/min.
+- **Durable harvest Solr writes**: granule docs are now flushed to Solr in batches during the harvest (with a single hard commit at the run boundary) instead of one write after the whole collection finishes, so large harvests are visible mid-run and survive an interruption. The shared drain loop lives in `Harvester.drain_futures`.
+
 ---
 
 ## [v2.2.2] — 2026-07-08

--- a/ecco_pipeline/harvesters/catds_harvester.py
+++ b/ecco_pipeline/harvesters/catds_harvester.py
@@ -1,7 +1,5 @@
 import logging
 import os
-import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Iterable
 
@@ -10,8 +8,6 @@ from harvesters.harvesterclasses import Granule, Harvester
 from utils.pipeline_utils.file_utils import get_date
 
 logger = logging.getLogger("pipeline")
-
-MAX_WORKERS = 3
 
 
 class CATDS_Harvester(Harvester):
@@ -32,8 +28,6 @@ class CATDS_Harvester(Harvester):
 
         for _, _, dt in to_process:
             os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
-
-        lock = threading.Lock()
 
         def process_granule(catds_granule: CATDSGranule, filename: str, dt: datetime):
             year = str(dt.year)
@@ -57,23 +51,18 @@ class CATDS_Harvester(Harvester):
                 except Exception as e:
                     success = False
                     error_message = str(e)
-                download_duration = int((datetime.utcnow() - download_start).total_seconds())
+                download_duration = int(
+                    (datetime.utcnow() - download_start).total_seconds()
+                )
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success, error_message, download_duration)
+            granule.update_item(
+                self.solr_docs, success, error_message, download_duration
+            )
             return granule.get_solr_docs()
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [
-                executor.submit(process_granule, *args) for args in to_process
-            ]
-            for future in as_completed(futures):
-                docs = future.result()
-                with lock:
-                    self.updated_solr_docs.extend(docs)
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_granule, to_process)
 
     def dl_file(self, src: str, dst: str):
         self._stream_download(src, dst)

--- a/ecco_pipeline/harvesters/cmr_harvester.py
+++ b/ecco_pipeline/harvesters/cmr_harvester.py
@@ -1,8 +1,6 @@
 import calendar
 import logging
 import os
-import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 import time
 from typing import Iterable
@@ -15,8 +13,6 @@ from utils.pipeline_utils.file_utils import get_date
 from utils.processing_utils.records import TimeBound
 
 logger = logging.getLogger("pipeline")
-
-MAX_WORKERS = 3
 
 
 class CMR_Harvester(Harvester):
@@ -50,8 +46,6 @@ class CMR_Harvester(Harvester):
         for _, _, dt in to_process:
             os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
 
-        lock = threading.Lock()
-
         def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
@@ -74,20 +68,18 @@ class CMR_Harvester(Harvester):
                 except Exception as e:
                     success = False
                     error_message = str(e)
-                download_duration = int((datetime.utcnow() - download_start).total_seconds())
+                download_duration = int(
+                    (datetime.utcnow() - download_start).total_seconds()
+                )
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success, error_message, download_duration)
+            granule.update_item(
+                self.solr_docs, success, error_message, download_duration
+            )
             return granule.get_solr_docs()
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [executor.submit(process_granule, *args) for args in to_process]
-            for future in as_completed(futures):
-                with lock:
-                    self.updated_solr_docs.extend(future.result())
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_granule, to_process)
 
     def fetch_atl_daily(self):
         to_process = []
@@ -104,9 +96,9 @@ class CMR_Harvester(Harvester):
         for _, _, dt in to_process:
             os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
 
-        lock = threading.Lock()
-
-        def process_monthly_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
+        def process_monthly_granule(
+            cmr_granule: CMRGranule, filename: str, dt: datetime
+        ):
             year = str(dt.year)
             month = str(dt.month)
             local_fp = os.path.join(self.target_dir, year, filename)
@@ -127,7 +119,9 @@ class CMR_Harvester(Harvester):
                     logger.warning(e)
                     dl_success = False
                     dl_error_message = str(e) or repr(e)
-                download_duration = int((datetime.utcnow() - download_start).total_seconds())
+                download_duration = int(
+                    (datetime.utcnow() - download_start).total_seconds()
+                )
             else:
                 logger.info(
                     f"{year}-{str(month).zfill(2)} monthly file up to date. Slicing to ensure entries in Solr..."
@@ -224,15 +218,7 @@ class CMR_Harvester(Harvester):
 
         # xarray/netCDF4 operations are CPU-bound — 1 worker avoids core saturation
         # while still freeing the main thread during I/O waits.
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            futures = [
-                executor.submit(process_monthly_granule, *args) for args in to_process
-            ]
-            for future in as_completed(futures):
-                with lock:
-                    self.updated_solr_docs.extend(future.result())
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_monthly_granule, to_process, max_workers=1)
 
     def fetch_tellus_grac_grfo(self):
         to_process = []
@@ -246,8 +232,6 @@ class CMR_Harvester(Harvester):
                 continue
             to_process.append((cmr_granule, filename, dt))
 
-        lock = threading.Lock()
-
         def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             local_fp = os.path.join(self.target_dir, filename)
             os.makedirs(self.target_dir, exist_ok=True)
@@ -256,7 +240,8 @@ class CMR_Harvester(Harvester):
             download_duration = 0
             if (
                 not os.path.exists(local_fp)
-                or datetime.fromtimestamp(os.path.getmtime(local_fp)) < cmr_granule.mod_time
+                or datetime.fromtimestamp(os.path.getmtime(local_fp))
+                < cmr_granule.mod_time
             ):
                 logger.info(f"Downloading {filename} to {local_fp}")
                 try:
@@ -268,7 +253,11 @@ class CMR_Harvester(Harvester):
                         (datetime.utcnow() - download_start).total_seconds()
                     )
                     parent_granule = Granule(
-                        self.ds_name, local_fp, dt, cmr_granule.mod_time, cmr_granule.url
+                        self.ds_name,
+                        local_fp,
+                        dt,
+                        cmr_granule.mod_time,
+                        cmr_granule.url,
                     )
                     parent_granule.update_item(
                         self.solr_docs, False, str(e) or repr(e), download_duration
@@ -277,7 +266,9 @@ class CMR_Harvester(Harvester):
             else:
                 logger.info("File up to date. Slicing to ensure entries in Solr...")
                 downloaded = False
-            download_duration = int((datetime.utcnow() - download_start).total_seconds())
+            download_duration = int(
+                (datetime.utcnow() - download_start).total_seconds()
+            )
 
             ds = xr.open_dataset(local_fp, decode_times=True)
 
@@ -285,11 +276,15 @@ class CMR_Harvester(Harvester):
                 "datetime64[M]"
             )
             time_end = (
-                np.datetime64(ds.attrs["time_coverage_end"][:-1]).astype("datetime64[M]") + 1
+                np.datetime64(ds.attrs["time_coverage_end"][:-1]).astype(
+                    "datetime64[M]"
+                )
+                + 1
             )
             months = np.arange(time_start, time_end, 1, dtype="datetime64[M]")
             monthly_cts = [
-                TimeBound(rec_avg_start=month, period="AVG_MON").center for month in months
+                TimeBound(rec_avg_start=month, period="AVG_MON").center
+                for month in months
             ]
 
             logger.info("Slicing aggregated granule into monthly granules...")
@@ -299,7 +294,9 @@ class CMR_Harvester(Harvester):
                 slice_error_message = ""
                 try:
                     success = True
-                    sub_ds = ds.sel(time=np.datetime64(monthly_center), method="nearest")
+                    sub_ds = ds.sel(
+                        time=np.datetime64(monthly_center), method="nearest"
+                    )
                     sub_ds_time = sub_ds.time.values
 
                     if not (
@@ -347,13 +344,7 @@ class CMR_Harvester(Harvester):
                 solr_docs.extend(monthly_granule.get_solr_docs())
             return solr_docs
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [executor.submit(process_granule, *args) for args in to_process]
-            for future in as_completed(futures):
-                with lock:
-                    self.updated_solr_docs.extend(future.result())
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_granule, to_process)
 
     def fetch_rdeft4(self):
         # Data filenames contain end of time coverage. To get data covering an
@@ -397,8 +388,6 @@ class CMR_Harvester(Harvester):
                 continue
             to_process.append((cmr_granule, filename, dt))
 
-        lock = threading.Lock()
-
         def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
@@ -422,20 +411,18 @@ class CMR_Harvester(Harvester):
                 except Exception as e:
                     success = False
                     error_message = str(e)
-                download_duration = int((datetime.utcnow() - download_start).total_seconds())
+                download_duration = int(
+                    (datetime.utcnow() - download_start).total_seconds()
+                )
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success, error_message, download_duration)
+            granule.update_item(
+                self.solr_docs, success, error_message, download_duration
+            )
             return granule.get_solr_docs()
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [executor.submit(process_granule, *args) for args in to_process]
-            for future in as_completed(futures):
-                with lock:
-                    self.updated_solr_docs.extend(future.result())
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_granule, to_process)
 
     def fetch_tolerance_filter(self):
         sorted_granules = sorted(self.cmr_granules, key=lambda x: x.url)
@@ -495,8 +482,6 @@ class CMR_Harvester(Harvester):
                 continue
             to_process.append((cmr_granule, filename, dt))
 
-        lock = threading.Lock()
-
         def process_granule(cmr_granule: CMRGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
@@ -520,20 +505,18 @@ class CMR_Harvester(Harvester):
                 except Exception as e:
                     success = False
                     error_message = str(e)
-                download_duration = int((datetime.utcnow() - download_start).total_seconds())
+                download_duration = int(
+                    (datetime.utcnow() - download_start).total_seconds()
+                )
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success, error_message, download_duration)
+            granule.update_item(
+                self.solr_docs, success, error_message, download_duration
+            )
             return granule.get_solr_docs()
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [executor.submit(process_granule, *args) for args in to_process]
-            for future in as_completed(futures):
-                with lock:
-                    self.updated_solr_docs.extend(future.result())
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_granule, to_process)
 
 
 def harvester(config: dict) -> str:

--- a/ecco_pipeline/harvesters/harvesterclasses.py
+++ b/ecco_pipeline/harvesters/harvesterclasses.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 
 import requests
@@ -11,6 +13,22 @@ from utils.pipeline_utils import file_utils, solr_utils
 logger = logging.getLogger("pipeline")
 
 CHUNK_SIZE = 1024 * 1024  # 1 MB
+
+# Number of concurrent download workers. Overridable per remote box via the
+# HARVEST_MAX_WORKERS env var without a code change. PO.DAAC/EDL-gated archives
+# generally tolerate well more than the old default of 3.
+DEFAULT_DOWNLOAD_WORKERS = 8
+
+# Buffered granule docs are flushed to Solr every SOLR_FLUSH_INTERVAL granules
+# during a harvest (instead of a single write at the very end), so large
+# harvests are durable and visible mid-run.
+SOLR_FLUSH_INTERVAL = 500
+
+# One requests.Session per worker thread, holding the Earthdata Login cookie and
+# a keep-alive connection so each granule download skips the TCP/TLS handshake
+# and the full EDL OAuth redirect chain after the first. netrc creds are picked
+# up automatically (trust_env is on by default).
+_thread_local = threading.local()
 
 
 class Granule:
@@ -85,6 +103,13 @@ class Harvester(Dataset):
             OUTPUT_DIR, self.ds_name, "harvested_granules"
         )
         self.updated_solr_docs: list = []
+        # Granule docs written to Solr but not yet flushed. Guarded by
+        # _flush_lock, which also serializes worker appends against a flush.
+        self._pending_solr_docs: list = []
+        self._flush_lock = threading.Lock()
+        self.max_workers: int = int(
+            os.environ.get("HARVEST_MAX_WORKERS", DEFAULT_DOWNLOAD_WORKERS)
+        )
 
         self.ensure_target_dir()
         solr_utils.clean_solr(config)
@@ -108,6 +133,26 @@ class Harvester(Dataset):
     def dl_file(self):
         raise NotImplementedError
 
+    def _get_download_session(self) -> requests.Session:
+        """
+        Return this worker thread's persistent download Session.
+
+        A per-thread Session keeps the EDL auth cookie and a pooled keep-alive
+        connection, so downloads after the first skip the ~1-2s TCP/TLS +
+        EDL OAuth redirect tax that a fresh requests.get() pays every call.
+        """
+        session = getattr(_thread_local, "download_session", None)
+        if session is None:
+            session = requests.Session()
+            adapter = requests.adapters.HTTPAdapter(
+                pool_connections=self.max_workers,
+                pool_maxsize=self.max_workers,
+            )
+            session.mount("https://", adapter)
+            session.mount("http://", adapter)
+            _thread_local.download_session = session
+        return session
+
     def _stream_download(self, src: str, dst: str):
         """
         Stream a file to disk and verify the transfer completed in full.
@@ -118,7 +163,8 @@ class Harvester(Dataset):
         Content-Length (e.g. chunked encoding) we can't know the expected size,
         so we fall back to rejecting only a genuinely empty file.
         """
-        with requests.get(src, stream=True, timeout=120) as r:
+        session = self._get_download_session()
+        with session.get(src, stream=True, timeout=120) as r:
             r.raise_for_status()
             declared = r.headers.get("Content-Length")
             expected_size = int(declared) if declared is not None else None
@@ -196,15 +242,73 @@ class Harvester(Dataset):
             return True
         return False
 
+    def flush_solr_docs(self, force: bool = False):
+        """
+        Write buffered granule docs to Solr using commitWithin batching.
+
+        Called periodically during a harvest so large runs are durable and
+        visible mid-run instead of a single write at the end. Only flushes once
+        SOLR_FLUSH_INTERVAL docs have accumulated unless force=True, which
+        flushes whatever remains (used at the end of the drain loop).
+
+        The pending list is copied and cleared under _flush_lock, then the
+        network write happens outside the lock so workers aren't blocked on it.
+        """
+        with self._flush_lock:
+            if not self._pending_solr_docs:
+                return
+            if not force and len(self._pending_solr_docs) < SOLR_FLUSH_INTERVAL:
+                return
+            batch = self._pending_solr_docs
+            self._pending_solr_docs = []
+            # Keep the complete set for post_fetch (last_download_dt, date ranges).
+            self.updated_solr_docs.extend(batch)
+
+        # commit=False -> commitWithin, so batched flushes don't trigger a
+        # commit/searcher-warming storm on every call. post_fetch forces a hard
+        # commit at the run boundary.
+        solr_utils.solr_update(batch, commit=False)
+
+    def drain_futures(self, process_granule, to_process, max_workers=None):
+        """
+        Run process_granule(*args) for each tuple in to_process across a thread
+        pool, buffering returned granule docs and flushing to Solr every
+        SOLR_FLUSH_INTERVAL granules. Flushes the remainder before returning.
+
+        Centralizes the accumulate + batched-flush pattern so each fetch_*
+        method only builds to_process and defines its per-granule worker.
+        """
+        if max_workers is None:
+            max_workers = self.max_workers
+
+        total = len(to_process)
+        completed = 0
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(process_granule, *args) for args in to_process]
+            for future in as_completed(futures):
+                docs = future.result()
+                completed += 1
+                if completed % SOLR_FLUSH_INTERVAL == 0:
+                    logger.info(
+                        f"{self.ds_name}: processed {completed}/{total} granules"
+                    )
+                if not docs:
+                    continue
+                with self._flush_lock:
+                    self._pending_solr_docs.extend(docs)
+                self.flush_solr_docs()
+
+        self.flush_solr_docs(force=True)
+        logger.info(f"Downloading {self.ds_name} complete")
+
     def post_fetch(self, source: str) -> str:
         check_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
 
         if self.updated_solr_docs:
-            r = solr_utils.solr_update(self.updated_solr_docs, r=True)
-            if r.status_code == 200:
-                logger.debug("Successfully created or updated Solr harvested documents")
-            else:
-                logger.exception("Failed to create Solr harvested documents")
+            # Batched flushes used commitWithin; force a hard commit so the
+            # count/date read-backs below see the latest state.
+            solr_utils.commit_solr()
+            logger.debug("Committed batched Solr harvested documents")
         else:
             logger.debug("No downloads required.")
 
@@ -295,7 +399,9 @@ class Harvester(Dataset):
         successful_count = solr_utils.solr_count(fq_base + ["harvest_success_b:true"])
 
         if not successful_count:
-            return "No usable granules harvested (either all failed or no data collected)"
+            return (
+                "No usable granules harvested (either all failed or no data collected)"
+            )
         elif failed_count:
             return f"{failed_count} harvested granules failed"
         return "All granules successfully harvested"

--- a/ecco_pipeline/harvesters/nsidc_harvester.py
+++ b/ecco_pipeline/harvesters/nsidc_harvester.py
@@ -1,11 +1,9 @@
 import logging
 import os
-import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Iterable
 
-from harvesters.enumeration.nsidc_enumerator import MAX_WORKERS, NSIDCGranule, search_nsidc
+from harvesters.enumeration.nsidc_enumerator import NSIDCGranule, search_nsidc
 from harvesters.harvesterclasses import Granule, Harvester
 from utils.pipeline_utils.file_utils import get_date
 
@@ -31,8 +29,6 @@ class NSIDC_Harvester(Harvester):
         for _, _, dt in to_process:
             os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
 
-        lock = threading.Lock()
-
         def process_granule(nsidc_granule: NSIDCGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
@@ -55,23 +51,18 @@ class NSIDC_Harvester(Harvester):
                 except Exception as e:
                     success = False
                     error_message = str(e)
-                download_duration = int((datetime.utcnow() - download_start).total_seconds())
+                download_duration = int(
+                    (datetime.utcnow() - download_start).total_seconds()
+                )
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success, error_message, download_duration)
+            granule.update_item(
+                self.solr_docs, success, error_message, download_duration
+            )
             return granule.get_solr_docs()
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [
-                executor.submit(process_granule, *args) for args in to_process
-            ]
-            for future in as_completed(futures):
-                docs = future.result()
-                with lock:
-                    self.updated_solr_docs.extend(docs)
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_granule, to_process)
 
     def dl_file(self, src: str, dst: str):
         self._stream_download(src, dst)

--- a/ecco_pipeline/harvesters/osisaf_harvester.py
+++ b/ecco_pipeline/harvesters/osisaf_harvester.py
@@ -1,12 +1,9 @@
 import logging
 import os
-import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Iterable
 
 from harvesters.enumeration.osisaf_enumerator import (
-    MAX_WORKERS,
     OSISAFGranule,
     search_osisaf,
 )
@@ -39,10 +36,6 @@ class OSISAF_Harvester(Harvester):
         for _, _, dt in to_process:
             os.makedirs(os.path.join(self.target_dir, str(dt.year)), exist_ok=True)
 
-        lock = threading.Lock()
-        total = len(to_process)
-        completed = 0
-
         def process_granule(osisaf_granule: OSISAFGranule, filename: str, dt: datetime):
             year = str(dt.year)
             local_fp = os.path.join(self.target_dir, year, filename)
@@ -65,26 +58,18 @@ class OSISAF_Harvester(Harvester):
                 except Exception as e:
                     success = False
                     error_message = str(e)
-                download_duration = int((datetime.utcnow() - download_start).total_seconds())
+                download_duration = int(
+                    (datetime.utcnow() - download_start).total_seconds()
+                )
             else:
                 logger.debug(f"{filename} already downloaded and up to date")
 
-            granule.update_item(self.solr_docs, success, error_message, download_duration)
+            granule.update_item(
+                self.solr_docs, success, error_message, download_duration
+            )
             return granule.get_solr_docs()
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [
-                executor.submit(process_granule, *args) for args in to_process
-            ]
-            for future in as_completed(futures):
-                docs = future.result()
-                with lock:
-                    self.updated_solr_docs.extend(docs)
-                    completed += 1
-                    if completed % 500 == 0:
-                        logger.info(f"{self.ds_name}: processed {completed}/{total} granules")
-
-        logger.info(f"Downloading {self.ds_name} complete")
+        self.drain_futures(process_granule, to_process)
 
     def dl_file(self, src: str, dst: str):
         self._stream_download(src, dst)

--- a/ecco_pipeline/tests/harvesters/test_catds_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_catds_harvester.py
@@ -2,6 +2,7 @@
 Unit tests for CATDS harvester.
 All Solr and HTTP calls are mocked - no external dependencies required.
 """
+
 import tempfile
 import unittest
 from datetime import datetime
@@ -30,7 +31,7 @@ def get_mock_config():
                 "standard_name": "sea_surface_salinity",
                 "units": "psu",
                 "pre_transformations": [],
-                "post_transformations": []
+                "post_transformations": [],
             }
         ],
         "original_dataset_title": "SMOS L3 Sea Surface Salinity",
@@ -42,7 +43,7 @@ def get_mock_config():
         "preprocessing": None,
         "t_version": 1.0,
         "a_version": 1.0,
-        "notes": ""
+        "notes": "",
     }
 
 
@@ -81,14 +82,16 @@ class CATDSHarvesterTestCase(unittest.TestCase):
 
                 self.assertEqual(len(h.updated_solr_docs), 0)
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_downloads_file(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_downloads_file(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch downloads files correctly."""
         mock_query.return_value = []
 
         mock_granule = CATDSGranule(
             url="https://data.catds.fr/cecos-locean/Ocean_products/L3_DEBIAS_LOCEAN_v10/SM_OPER_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -104,14 +107,16 @@ class CATDSHarvesterTestCase(unittest.TestCase):
                 mock_requests.assert_called_once()
                 self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_skips_out_of_range_dates(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_skips_out_of_range_dates(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch skips granules outside date range."""
         mock_query.return_value = []
 
         mock_granule = CATDSGranule(
             url="https://data.catds.fr/cecos-locean/Ocean_products/L3_DEBIAS_LOCEAN_v10/SM_OPER_20190115.nc",
-            mod_time=datetime(2019, 1, 16, 10, 30)
+            mod_time=datetime(2019, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -124,14 +129,16 @@ class CATDSHarvesterTestCase(unittest.TestCase):
 
                 mock_requests.assert_not_called()
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_handles_download_failure(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_handles_download_failure(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch handles download failures gracefully."""
         mock_query.return_value = []
 
         mock_granule = CATDSGranule(
             url="https://data.catds.fr/cecos-locean/Ocean_products/L3_DEBIAS_LOCEAN_v10/SM_OPER_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -145,18 +152,22 @@ class CATDSHarvesterTestCase(unittest.TestCase):
                 h.fetch()
 
                 self.assertGreater(len(h.updated_solr_docs), 0)
-                granule_doc = [d for d in h.updated_solr_docs if d.get("type_s") == "granule"][0]
+                granule_doc = [
+                    d for d in h.updated_solr_docs if d.get("type_s") == "granule"
+                ][0]
                 self.assertFalse(granule_doc["harvest_success_b"])
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_multiple_granules(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_multiple_granules(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch handles multiple granules."""
         mock_query.return_value = []
 
         mock_granules = [
             CATDSGranule(
                 url=f"https://data.catds.fr/cecos-locean/Ocean_products/L3_DEBIAS_LOCEAN_v10/SM_OPER_202001{i:02d}.nc",
-                mod_time=datetime(2020, 1, i+1, 10, 30)
+                mod_time=datetime(2020, 1, i + 1, 10, 30),
             )
             for i in range(15, 18)
         ]
@@ -184,7 +195,9 @@ class CATDSHarvesterTestCase(unittest.TestCase):
 class CATDSHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function(self, mock_search, mock_count, mock_update, mock_clean, mock_query):
+    def test_harvester_function(
+        self, mock_search, mock_count, mock_update, mock_clean, mock_query
+    ):
         """Test the harvester() function runs complete workflow."""
         mock_query.return_value = []
         mock_search.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_catds_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_catds_harvester.py
@@ -53,6 +53,13 @@ def get_mock_config():
 class CATDSHarvesterTestCase(unittest.TestCase):
     """Tests for the CATDS_Harvester class."""
 
+    def setUp(self):
+        # fetch() now writes granule docs to Solr mid-run (drain_futures ->
+        # flush_solr_docs), so mock the write to keep these tests offline.
+        patcher = patch("harvesters.harvesterclasses.solr_utils.solr_update")
+        self.mock_solr_update = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_harvester_initialization(self, mock_search, mock_clean, mock_query):
         """Test CATDS_Harvester initializes correctly."""
         mock_query.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
@@ -2,6 +2,7 @@
 Unit tests for CMR harvester.
 All Solr and HTTP calls are mocked - no external dependencies required.
 """
+
 import os
 import tempfile
 import unittest
@@ -33,7 +34,7 @@ def get_mock_config():
                 "standard_name": "sea_surface_height_above_sea_level",
                 "units": "m",
                 "pre_transformations": [],
-                "post_transformations": []
+                "post_transformations": [],
             }
         ],
         "original_dataset_title": "MEaSUREs Gridded Sea Surface Height Anomalies",
@@ -45,7 +46,7 @@ def get_mock_config():
         "preprocessing": None,
         "t_version": 1.0,
         "a_version": 1.0,
-        "notes": ""
+        "notes": "",
     }
 
 
@@ -65,7 +66,9 @@ def create_mock_cmr_granule(filename, date, provider="POCLOUD"):
 class CMRHarvesterTestCase(unittest.TestCase):
     """Tests for the CMR_Harvester class."""
 
-    def test_harvester_initialization(self, mock_cmr_query, mock_clean, mock_solr_query):
+    def test_harvester_initialization(
+        self, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test CMR_Harvester initializes correctly."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -78,7 +81,10 @@ class CMRHarvesterTestCase(unittest.TestCase):
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
                 h = CMR_Harvester(config)
 
-                self.assertEqual(h.ds_name, "SEA_SURFACE_HEIGHT_ALT_GRIDS_L4_2SATS_5DAY_6THDEG_V_JPL2205")
+                self.assertEqual(
+                    h.ds_name,
+                    "SEA_SURFACE_HEIGHT_ALT_GRIDS_L4_2SATS_5DAY_6THDEG_V_JPL2205",
+                )
                 self.assertEqual(h.cmr_concept_id, "C2036882072-POCLOUD")
                 self.assertEqual(h.provider, "POCLOUD")
                 mock_cmr_query.assert_called_once()
@@ -99,15 +105,16 @@ class CMRHarvesterTestCase(unittest.TestCase):
 
                 self.assertEqual(len(h.updated_solr_docs), 0)
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_downloads_file(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_fetch_downloads_file(
+        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test fetch downloads files correctly."""
         mock_solr_query.return_value = []
 
         # Create mock granule
         mock_granule = create_mock_cmr_granule(
-            "ssh_grids_v2205_2020011512.nc",
-            datetime(2020, 1, 16, 10, 30)
+            "ssh_grids_v2205_2020011512.nc", datetime(2020, 1, 16, 10, 30)
         )
         mock_query_instance = MagicMock()
         mock_query_instance.query.return_value = [mock_granule]
@@ -127,15 +134,16 @@ class CMRHarvesterTestCase(unittest.TestCase):
                 mock_requests.assert_called_once()
                 self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_skips_nrt_files(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_fetch_skips_nrt_files(
+        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test fetch skips NRT (Near Real Time) files."""
         mock_solr_query.return_value = []
 
         # Create mock NRT granule
         mock_granule = create_mock_cmr_granule(
-            "ssh_grids_v2205_NRT_2020011512.nc",
-            datetime(2020, 1, 16, 10, 30)
+            "ssh_grids_v2205_NRT_2020011512.nc", datetime(2020, 1, 16, 10, 30)
         )
         mock_query_instance = MagicMock()
         mock_query_instance.query.return_value = [mock_granule]
@@ -151,15 +159,16 @@ class CMRHarvesterTestCase(unittest.TestCase):
                 # Should not download NRT files
                 mock_requests.assert_not_called()
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_skips_out_of_range_dates(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_fetch_skips_out_of_range_dates(
+        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test fetch skips granules outside date range."""
         mock_solr_query.return_value = []
 
         # Create mock granule with date outside range (2019)
         mock_granule = create_mock_cmr_granule(
-            "ssh_grids_v2205_2019011512.nc",
-            datetime(2019, 1, 16, 10, 30)
+            "ssh_grids_v2205_2019011512.nc", datetime(2019, 1, 16, 10, 30)
         )
         mock_query_instance = MagicMock()
         mock_query_instance.query.return_value = [mock_granule]
@@ -175,14 +184,15 @@ class CMRHarvesterTestCase(unittest.TestCase):
                 # Should not download
                 mock_requests.assert_not_called()
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_handles_download_failure(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_fetch_handles_download_failure(
+        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test fetch handles download failures gracefully."""
         mock_solr_query.return_value = []
 
         mock_granule = create_mock_cmr_granule(
-            "ssh_grids_v2205_2020011512.nc",
-            datetime(2020, 1, 16, 10, 30)
+            "ssh_grids_v2205_2020011512.nc", datetime(2020, 1, 16, 10, 30)
         )
         mock_query_instance = MagicMock()
         mock_query_instance.query.return_value = [mock_granule]
@@ -200,17 +210,20 @@ class CMRHarvesterTestCase(unittest.TestCase):
 
                 # Should still create Solr docs with failure status
                 self.assertGreater(len(h.updated_solr_docs), 0)
-                granule_doc = [d for d in h.updated_solr_docs if d.get("type_s") == "granule"][0]
+                granule_doc = [
+                    d for d in h.updated_solr_docs if d.get("type_s") == "granule"
+                ][0]
                 self.assertFalse(granule_doc["harvest_success_b"])
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_skips_existing_up_to_date_files(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_fetch_skips_existing_up_to_date_files(
+        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test fetch skips files that are already up to date."""
         mock_solr_query.return_value = []
 
         mock_granule = create_mock_cmr_granule(
-            "ssh_grids_v2205_2020011512.nc",
-            datetime(2020, 1, 16, 10, 30)
+            "ssh_grids_v2205_2020011512.nc", datetime(2020, 1, 16, 10, 30)
         )
         mock_query_instance = MagicMock()
         mock_query_instance.query.return_value = [mock_granule]
@@ -225,7 +238,7 @@ class CMRHarvesterTestCase(unittest.TestCase):
                 # Mark file as already downloaded and up to date
                 h.solr_docs["ssh_grids_v2205_2020011512.nc"] = {
                     "harvest_success_b": True,
-                    "download_time_dt": "2020-12-01T00:00:00Z"
+                    "download_time_dt": "2020-12-01T00:00:00Z",
                 }
 
                 h.fetch()
@@ -233,15 +246,16 @@ class CMRHarvesterTestCase(unittest.TestCase):
                 # Should not download
                 mock_requests.assert_not_called()
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_multiple_granules(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_fetch_multiple_granules(
+        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test fetch handles multiple granules."""
         mock_solr_query.return_value = []
 
         mock_granules = [
             create_mock_cmr_granule(
-                f"ssh_grids_v2205_202001{i:02d}12.nc",
-                datetime(2020, 1, i+1, 10, 30)
+                f"ssh_grids_v2205_202001{i:02d}12.nc", datetime(2020, 1, i + 1, 10, 30)
             )
             for i in range(1, 4)
         ]
@@ -263,8 +277,10 @@ class CMRHarvesterTestCase(unittest.TestCase):
                 self.assertEqual(len(h.updated_solr_docs), 3)
 
     @patch("harvesters.cmr_harvester.time.sleep")
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_dl_file_retries_on_failure(self, mock_requests, mock_sleep, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_dl_file_retries_on_failure(
+        self, mock_requests, mock_sleep, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test dl_file retries on initial failure."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -308,7 +324,9 @@ class CMRHarvesterTestCase(unittest.TestCase):
 class CMRHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function_standard(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_standard(
+        self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query
+    ):
         """Test the harvester() function runs standard fetch workflow."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -327,7 +345,9 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
                 self.assertIsInstance(status, str)
                 mock_update.assert_called()
 
-    def test_harvester_function_atl20(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_atl20(
+        self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query
+    ):
         """Test the harvester() function calls fetch_atl_daily for ATL20."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -342,11 +362,13 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch.object(CMR_Harvester, 'fetch_atl_daily') as mock_fetch:
+                with patch.object(CMR_Harvester, "fetch_atl_daily") as mock_fetch:
                     harvester(config)
                     mock_fetch.assert_called_once()
 
-    def test_harvester_function_tellus_grac_grfo(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_tellus_grac_grfo(
+        self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query
+    ):
         """Test the harvester() function calls fetch_tellus_grac_grfo for TELLUS dataset."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -361,11 +383,15 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch.object(CMR_Harvester, 'fetch_tellus_grac_grfo') as mock_fetch:
+                with patch.object(
+                    CMR_Harvester, "fetch_tellus_grac_grfo"
+                ) as mock_fetch:
                     harvester(config)
                     mock_fetch.assert_called_once()
 
-    def test_harvester_function_rdeft4(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_rdeft4(
+        self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query
+    ):
         """Test the harvester() function calls fetch_rdeft4 for RDEFT4."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -380,11 +406,13 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch.object(CMR_Harvester, 'fetch_rdeft4') as mock_fetch:
+                with patch.object(CMR_Harvester, "fetch_rdeft4") as mock_fetch:
                     harvester(config)
                     mock_fetch.assert_called_once()
 
-    def test_harvester_function_tellus_tolerance(self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query):
+    def test_harvester_function_tellus_tolerance(
+        self, mock_cmr_query, mock_count, mock_update, mock_clean, mock_solr_query
+    ):
         """Test the harvester() function calls fetch_tolerance_filter for other TELLUS datasets."""
         mock_solr_query.return_value = []
         mock_query_instance = MagicMock()
@@ -399,7 +427,9 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch.object(CMR_Harvester, 'fetch_tolerance_filter') as mock_fetch:
+                with patch.object(
+                    CMR_Harvester, "fetch_tolerance_filter"
+                ) as mock_fetch:
                     harvester(config)
                     mock_fetch.assert_called_once()
 
@@ -410,15 +440,19 @@ class CMRHarvesterSpecialFetchTestCase(unittest.TestCase):
     @patch("harvesters.harvesterclasses.solr_utils.solr_query")
     @patch("harvesters.harvesterclasses.solr_utils.clean_solr")
     @patch("harvesters.cmr_harvester.CMRQuery")
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_rdeft4_filters_end_of_month(self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query):
+    @patch("requests.Session.get")
+    def test_fetch_rdeft4_filters_end_of_month(
+        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+    ):
         """Test fetch_rdeft4 filters to end-of-month granules."""
         mock_solr_query.return_value = []
 
         # Create granules for different days
         mock_granules = [
             create_mock_cmr_granule("RDEFT4_20200115.nc", datetime(2020, 1, 16)),
-            create_mock_cmr_granule("RDEFT4_20200131.nc", datetime(2020, 2, 1)),  # End of month
+            create_mock_cmr_granule(
+                "RDEFT4_20200131.nc", datetime(2020, 2, 1)
+            ),  # End of month
             create_mock_cmr_granule("RDEFT4_20200220.nc", datetime(2020, 2, 21)),
         ]
         mock_query_instance = MagicMock()

--- a/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_cmr_harvester.py
@@ -66,6 +66,13 @@ def create_mock_cmr_granule(filename, date, provider="POCLOUD"):
 class CMRHarvesterTestCase(unittest.TestCase):
     """Tests for the CMR_Harvester class."""
 
+    def setUp(self):
+        # fetch() now writes granule docs to Solr mid-run (drain_futures ->
+        # flush_solr_docs), so mock the write to keep these tests offline.
+        patcher = patch("harvesters.harvesterclasses.solr_utils.solr_update")
+        self.mock_solr_update = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_harvester_initialization(
         self, mock_cmr_query, mock_clean, mock_solr_query
     ):
@@ -437,12 +444,18 @@ class CMRHarvesterFunctionTestCase(unittest.TestCase):
 class CMRHarvesterSpecialFetchTestCase(unittest.TestCase):
     """Tests for special fetch methods (fetch_rdeft4, fetch_tolerance_filter, etc.)."""
 
+    @patch("harvesters.harvesterclasses.solr_utils.solr_update")
     @patch("harvesters.harvesterclasses.solr_utils.solr_query")
     @patch("harvesters.harvesterclasses.solr_utils.clean_solr")
     @patch("harvesters.cmr_harvester.CMRQuery")
     @patch("requests.Session.get")
     def test_fetch_rdeft4_filters_end_of_month(
-        self, mock_requests, mock_cmr_query, mock_clean, mock_solr_query
+        self,
+        mock_requests,
+        mock_cmr_query,
+        mock_clean,
+        mock_solr_query,
+        mock_solr_update,
     ):
         """Test fetch_rdeft4 filters to end-of-month granules."""
         mock_solr_query.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_harvesterclasses.py
+++ b/ecco_pipeline/tests/harvesters/test_harvesterclasses.py
@@ -2,6 +2,7 @@
 Unit tests for harvester base classes (Granule and Harvester).
 All Solr calls are mocked - no Solr deployment required.
 """
+
 import os
 import tempfile
 import unittest
@@ -24,11 +25,7 @@ class GranuleTestCase(unittest.TestCase):
     def test_granule_initialization(self):
         """Test that Granule initializes correctly."""
         granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
+            self.ds_name, self.local_fp, self.date, self.modified_time, self.url
         )
 
         self.assertEqual(granule.ds_name, self.ds_name)
@@ -41,11 +38,7 @@ class GranuleTestCase(unittest.TestCase):
     def test_gen_granule_doc(self):
         """Test that granule Solr document is generated correctly."""
         granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
+            self.ds_name, self.local_fp, self.date, self.modified_time, self.url
         )
 
         self.assertEqual(granule.solr_item["type_s"], "granule")
@@ -60,11 +53,7 @@ class GranuleTestCase(unittest.TestCase):
         mock_md5.return_value = "abc123checksum"
 
         granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
+            self.ds_name, self.local_fp, self.date, self.modified_time, self.url
         )
 
         # Create a temporary file for the test
@@ -79,7 +68,9 @@ class GranuleTestCase(unittest.TestCase):
 
             self.assertTrue(granule.solr_item["harvest_success_b"])
             self.assertEqual(granule.solr_item["checksum_s"], "abc123checksum")
-            self.assertEqual(granule.solr_item["pre_transformation_file_path_s"], temp_path)
+            self.assertEqual(
+                granule.solr_item["pre_transformation_file_path_s"], temp_path
+            )
             self.assertGreater(granule.solr_item["file_size_l"], 0)
         finally:
             os.unlink(temp_path)
@@ -87,11 +78,7 @@ class GranuleTestCase(unittest.TestCase):
     def test_update_item_failure(self):
         """Test update_item with failed download."""
         granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
+            self.ds_name, self.local_fp, self.date, self.modified_time, self.url
         )
 
         solr_docs = {}
@@ -104,16 +91,10 @@ class GranuleTestCase(unittest.TestCase):
     def test_update_item_with_existing_id(self):
         """Test update_item preserves existing Solr ID."""
         granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
+            self.ds_name, self.local_fp, self.date, self.modified_time, self.url
         )
 
-        solr_docs = {
-            "test_file_20200101.nc": {"id": "existing-solr-id-123"}
-        }
+        solr_docs = {"test_file_20200101.nc": {"id": "existing-solr-id-123"}}
         granule.update_item(solr_docs, success=False)
 
         self.assertEqual(granule.solr_item["id"], "existing-solr-id-123")
@@ -121,11 +102,7 @@ class GranuleTestCase(unittest.TestCase):
     def test_get_solr_docs(self):
         """Test get_solr_docs returns one granule document."""
         granule = Granule(
-            self.ds_name,
-            self.local_fp,
-            self.date,
-            self.modified_time,
-            self.url
+            self.ds_name, self.local_fp, self.date, self.modified_time, self.url
         )
 
         docs = granule.get_solr_docs()
@@ -157,7 +134,7 @@ class HarvesterTestCase(unittest.TestCase):
                     "standard_name": "test",
                     "units": "1",
                     "pre_transformations": [],
-                    "post_transformations": []
+                    "post_transformations": [],
                 }
             ],
             "original_dataset_title": "Test Dataset",
@@ -169,7 +146,7 @@ class HarvesterTestCase(unittest.TestCase):
             "preprocessing": None,
             "t_version": 1.0,
             "a_version": 1.0,
-            "notes": ""
+            "notes": "",
         }
 
     def test_harvester_initialization(self, mock_clean, mock_query):
@@ -219,10 +196,7 @@ class HarvesterTestCase(unittest.TestCase):
                 harvester = Harvester(config)
 
                 # File not in solr_docs
-                result = harvester.check_update(
-                    "new_file.nc",
-                    datetime(2020, 1, 1)
-                )
+                result = harvester.check_update("new_file.nc", datetime(2020, 1, 1))
                 self.assertTrue(result)
 
     def test_check_update_failed_previous(self, mock_clean, mock_query):
@@ -238,13 +212,10 @@ class HarvesterTestCase(unittest.TestCase):
                 # Add failed file to solr_docs
                 harvester.solr_docs["failed_file.nc"] = {
                     "harvest_success_b": False,
-                    "download_time_dt": "2020-01-01T00:00:00Z"
+                    "download_time_dt": "2020-01-01T00:00:00Z",
                 }
 
-                result = harvester.check_update(
-                    "failed_file.nc",
-                    datetime(2020, 1, 1)
-                )
+                result = harvester.check_update("failed_file.nc", datetime(2020, 1, 1))
                 self.assertTrue(result)
 
     def test_check_update_outdated_file(self, mock_clean, mock_query):
@@ -260,13 +231,12 @@ class HarvesterTestCase(unittest.TestCase):
                 # Add outdated file to solr_docs
                 harvester.solr_docs["outdated_file.nc"] = {
                     "harvest_success_b": True,
-                    "download_time_dt": "2020-01-01T00:00:00Z"
+                    "download_time_dt": "2020-01-01T00:00:00Z",
                 }
 
                 # New modification time is later
                 result = harvester.check_update(
-                    "outdated_file.nc",
-                    datetime(2020, 6, 1)
+                    "outdated_file.nc", datetime(2020, 6, 1)
                 )
                 self.assertTrue(result)
 
@@ -283,14 +253,11 @@ class HarvesterTestCase(unittest.TestCase):
                 # Add up-to-date file to solr_docs
                 harvester.solr_docs["current_file.nc"] = {
                     "harvest_success_b": True,
-                    "download_time_dt": "2020-06-01T00:00:00Z"
+                    "download_time_dt": "2020-06-01T00:00:00Z",
                 }
 
                 # Modification time is earlier than download time
-                result = harvester.check_update(
-                    "current_file.nc",
-                    datetime(2020, 1, 1)
-                )
+                result = harvester.check_update("current_file.nc", datetime(2020, 1, 1))
                 self.assertFalse(result)
 
     def test_need_to_download_missing_file(self, mock_clean, mock_query):
@@ -308,7 +275,7 @@ class HarvesterTestCase(unittest.TestCase):
                     "/nonexistent/path/file.nc",
                     datetime(2020, 1, 1),
                     datetime(2020, 1, 1),
-                    "https://example.com/file.nc"
+                    "https://example.com/file.nc",
                 )
 
                 self.assertTrue(harvester.need_to_download(granule))
@@ -338,7 +305,7 @@ class HarvesterTestCase(unittest.TestCase):
                         temp_path,
                         datetime(2020, 1, 1),
                         datetime(2020, 6, 1),  # Newer modification time
-                        "https://example.com/file.nc"
+                        "https://example.com/file.nc",
                     )
 
                     self.assertTrue(harvester.need_to_download(granule))
@@ -356,8 +323,7 @@ class HarvesterTestCase(unittest.TestCase):
                 harvester = Harvester(config)
 
                 ds_doc = harvester.make_ds_doc(
-                    "https://example.com/source",
-                    "2020-01-01T00:00:00Z"
+                    "https://example.com/source", "2020-01-01T00:00:00Z"
                 )
 
                 self.assertEqual(ds_doc["type_s"], "dataset")
@@ -379,7 +345,9 @@ class HarvesterTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch("harvesters.harvesterclasses.solr_utils.solr_count", return_value=0):
+                with patch(
+                    "harvesters.harvesterclasses.solr_utils.solr_count", return_value=0
+                ):
                     harvester = Harvester(config)
                     harvester.updated_solr_docs = []
 
@@ -387,8 +355,11 @@ class HarvesterTestCase(unittest.TestCase):
 
                     self.assertIn("harvested", status.lower())
 
+    @patch("harvesters.harvesterclasses.solr_utils.commit_solr")
     @patch("harvesters.harvesterclasses.solr_utils.solr_update")
-    def test_post_fetch_with_updates(self, mock_update, mock_clean, mock_query):
+    def test_post_fetch_with_updates(
+        self, mock_update, mock_commit, mock_clean, mock_query
+    ):
         """Test post_fetch when downloads occurred."""
         mock_query.return_value = []
         mock_response = Mock()
@@ -399,14 +370,16 @@ class HarvesterTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch("harvesters.harvesterclasses.solr_utils.solr_count", return_value=0):
+                with patch(
+                    "harvesters.harvesterclasses.solr_utils.solr_count", return_value=0
+                ):
                     harvester = Harvester(config)
                     harvester.updated_solr_docs = [
                         {
                             "type_s": "granule",
                             "harvest_success_b": True,
                             "download_time_dt": "2020-01-01T00:00:00Z",
-                            "date_dt": "2020-01-01T00:00:00Z"
+                            "date_dt": "2020-01-01T00:00:00Z",
                         }
                     ]
 
@@ -423,7 +396,10 @@ class HarvesterTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch("harvesters.harvesterclasses.solr_utils.solr_count", side_effect=[0, 1]):
+                with patch(
+                    "harvesters.harvesterclasses.solr_utils.solr_count",
+                    side_effect=[0, 1],
+                ):
                     harvester = Harvester(config)
                     status = harvester.harvester_status()
 
@@ -437,7 +413,10 @@ class HarvesterTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("harvesters.harvesterclasses.OUTPUT_DIR", tmpdir):
-                with patch("harvesters.harvesterclasses.solr_utils.solr_count", side_effect=[2, 1]):
+                with patch(
+                    "harvesters.harvesterclasses.solr_utils.solr_count",
+                    side_effect=[2, 1],
+                ):
                     harvester = Harvester(config)
                     status = harvester.harvester_status()
 

--- a/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
@@ -2,6 +2,7 @@
 Unit tests for NSIDC harvester.
 All Solr and HTTP calls are mocked - no external dependencies required.
 """
+
 import tempfile
 import unittest
 from datetime import datetime
@@ -30,7 +31,7 @@ def get_mock_config():
                 "standard_name": "sea_ice_area_fraction",
                 "units": "1",
                 "pre_transformations": [],
-                "post_transformations": []
+                "post_transformations": [],
             }
         ],
         "original_dataset_title": "NOAA/NSIDC Climate Data Record",
@@ -42,7 +43,7 @@ def get_mock_config():
         "preprocessing": None,
         "t_version": 1.0,
         "a_version": 1.0,
-        "notes": ""
+        "notes": "",
     }
 
 
@@ -81,15 +82,17 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
 
                 self.assertEqual(len(h.updated_solr_docs), 0)
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_downloads_file(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_downloads_file(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch downloads files correctly."""
         mock_query.return_value = []
 
         # Create mock granule
         mock_granule = NSIDCGranule(
             url="https://example.com/seaice_conc_daily_nh_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -107,15 +110,17 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
                 mock_requests.assert_called_once()
                 self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_skips_out_of_range_dates(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_skips_out_of_range_dates(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch skips granules outside date range."""
         mock_query.return_value = []
 
         # Create mock granule with date outside range
         mock_granule = NSIDCGranule(
             url="https://example.com/seaice_conc_daily_nh_20190115.nc",  # 2019
-            mod_time=datetime(2019, 1, 16, 10, 30)
+            mod_time=datetime(2019, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -129,14 +134,16 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
                 # Should not download
                 mock_requests.assert_not_called()
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_handles_download_failure(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_handles_download_failure(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch handles download failures gracefully."""
         mock_query.return_value = []
 
         mock_granule = NSIDCGranule(
             url="https://example.com/seaice_conc_daily_nh_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -153,18 +160,22 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
                 # Should still create Solr docs with failure status
                 self.assertGreater(len(h.updated_solr_docs), 0)
                 # Check that harvest_success_b is False
-                granule_doc = [d for d in h.updated_solr_docs if d.get("type_s") == "granule"][0]
+                granule_doc = [
+                    d for d in h.updated_solr_docs if d.get("type_s") == "granule"
+                ][0]
                 self.assertFalse(granule_doc["harvest_success_b"])
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_skips_existing_up_to_date_files(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_skips_existing_up_to_date_files(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch skips files that are already up to date."""
         # Setup existing Solr doc
         mock_query.return_value = []
 
         mock_granule = NSIDCGranule(
             url="https://example.com/seaice_conc_daily_nh_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -177,7 +188,7 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
                 # Mark file as already downloaded and up to date
                 h.solr_docs["seaice_conc_daily_nh_20200115.nc"] = {
                     "harvest_success_b": True,
-                    "download_time_dt": "2020-12-01T00:00:00Z"  # Downloaded later than mod_time
+                    "download_time_dt": "2020-12-01T00:00:00Z",  # Downloaded later than mod_time
                 }
 
                 h.fetch()
@@ -194,7 +205,9 @@ class NSIDCHarvesterTestCase(unittest.TestCase):
 class NSIDCHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function(self, mock_search, mock_count, mock_update, mock_clean, mock_query):
+    def test_harvester_function(
+        self, mock_search, mock_count, mock_update, mock_clean, mock_query
+    ):
         """Test the harvester() function runs complete workflow."""
         mock_query.return_value = []
         mock_search.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_nsidc_harvester.py
@@ -53,6 +53,13 @@ def get_mock_config():
 class NSIDCHarvesterTestCase(unittest.TestCase):
     """Tests for the NSIDC_Harvester class."""
 
+    def setUp(self):
+        # fetch() now writes granule docs to Solr mid-run (drain_futures ->
+        # flush_solr_docs), so mock the write to keep these tests offline.
+        patcher = patch("harvesters.harvesterclasses.solr_utils.solr_update")
+        self.mock_solr_update = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_harvester_initialization(self, mock_search, mock_clean, mock_query):
         """Test NSIDC_Harvester initializes correctly."""
         mock_query.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
@@ -2,6 +2,7 @@
 Unit tests for OSISAF harvester.
 All Solr and HTTP calls are mocked - no external dependencies required.
 """
+
 import tempfile
 import unittest
 from datetime import datetime
@@ -30,7 +31,7 @@ def get_mock_config():
                 "standard_name": "sea_ice_area_fraction",
                 "units": "1",
                 "pre_transformations": [],
-                "post_transformations": []
+                "post_transformations": [],
             }
         ],
         "original_dataset_title": "OSISAF Sea Ice Concentration",
@@ -42,7 +43,7 @@ def get_mock_config():
         "preprocessing": None,
         "t_version": 1.0,
         "a_version": 1.0,
-        "notes": ""
+        "notes": "",
     }
 
 
@@ -81,14 +82,16 @@ class OSISAFHarvesterTestCase(unittest.TestCase):
 
                 self.assertEqual(len(h.updated_solr_docs), 0)
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_downloads_file(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_downloads_file(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch downloads files correctly."""
         mock_query.return_value = []
 
         mock_granule = OSISAFGranule(
             url="https://thredds.met.no/thredds/fileServer/ice_conc_nh_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -104,15 +107,17 @@ class OSISAFHarvesterTestCase(unittest.TestCase):
                 mock_requests.assert_called_once()
                 self.assertEqual(len(h.updated_solr_docs), 1)  # granule only
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_skips_icdrft_files(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_skips_icdrft_files(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch skips fast track (icdrft) files."""
         mock_query.return_value = []
 
         # Create mock granule with icdrft in filename
         mock_granule = OSISAFGranule(
             url="https://thredds.met.no/thredds/fileServer/ice_conc_nh_icdrft_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -126,14 +131,16 @@ class OSISAFHarvesterTestCase(unittest.TestCase):
                 # Should not download icdrft files
                 mock_requests.assert_not_called()
 
-    @patch("harvesters.harvesterclasses.requests.get")
-    def test_fetch_handles_download_failure(self, mock_requests, mock_search, mock_clean, mock_query):
+    @patch("requests.Session.get")
+    def test_fetch_handles_download_failure(
+        self, mock_requests, mock_search, mock_clean, mock_query
+    ):
         """Test fetch handles download failures gracefully."""
         mock_query.return_value = []
 
         mock_granule = OSISAFGranule(
             url="https://thredds.met.no/thredds/fileServer/ice_conc_nh_20200115.nc",
-            mod_time=datetime(2020, 1, 16, 10, 30)
+            mod_time=datetime(2020, 1, 16, 10, 30),
         )
         mock_search.return_value = [mock_granule]
 
@@ -147,7 +154,9 @@ class OSISAFHarvesterTestCase(unittest.TestCase):
                 h.fetch()
 
                 self.assertGreater(len(h.updated_solr_docs), 0)
-                granule_doc = [d for d in h.updated_solr_docs if d.get("type_s") == "granule"][0]
+                granule_doc = [
+                    d for d in h.updated_solr_docs if d.get("type_s") == "granule"
+                ][0]
                 self.assertFalse(granule_doc["harvest_success_b"])
 
 
@@ -159,7 +168,9 @@ class OSISAFHarvesterTestCase(unittest.TestCase):
 class OSISAFHarvesterFunctionTestCase(unittest.TestCase):
     """Tests for the harvester() module function."""
 
-    def test_harvester_function(self, mock_search, mock_count, mock_update, mock_clean, mock_query):
+    def test_harvester_function(
+        self, mock_search, mock_count, mock_update, mock_clean, mock_query
+    ):
         """Test the harvester() function runs complete workflow."""
         mock_query.return_value = []
         mock_search.return_value = []

--- a/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
+++ b/ecco_pipeline/tests/harvesters/test_osisaf_harvester.py
@@ -53,6 +53,13 @@ def get_mock_config():
 class OSISAFHarvesterTestCase(unittest.TestCase):
     """Tests for the OSISAF_Harvester class."""
 
+    def setUp(self):
+        # fetch() now writes granule docs to Solr mid-run (drain_futures ->
+        # flush_solr_docs), so mock the write to keep these tests offline.
+        patcher = patch("harvesters.harvesterclasses.solr_utils.solr_update")
+        self.mock_solr_update = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_harvester_initialization(self, mock_search, mock_clean, mock_query):
         """Test OSISAF_Harvester initializes correctly."""
         mock_query.return_value = []

--- a/ecco_pipeline/utils/pipeline_utils/file_utils.py
+++ b/ecco_pipeline/utils/pipeline_utils/file_utils.py
@@ -9,8 +9,10 @@ def md5(fname: str) -> str:
     """
     hash_md5 = hashlib.md5()
 
+    # 1 MB reads keep the post-download checksum off the critical path for large
+    # granules (vs. many tiny 4 KB reads).
     with open(fname, "rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 


### PR DESCRIPTION
## Summary

Harvesting was downloading ~70 granules/min and writing nothing to Solr until the very end of a collection. This PR removes the per-file connection/auth overhead, raises download concurrency, and makes Solr writes durable and visible mid-run — observed throughput on a test collection jumped several-fold.

## Changes

- **Per-worker keep-alive sessions**: each download worker now reuses a `requests.Session`, so downloads after the first skip the TCP/TLS handshake and the full Earthdata Login OAuth redirect chain that every granule previously paid (~1–2s/file). This was the dominant cost.
- **Batched, durable Solr writes**: granule docs are flushed to Solr in batches during the harvest (via `commitWithin`) with a single hard commit at the run boundary, instead of one large write only after the entire collection finished. Large harvests are now visible mid-run and survive an interruption.
- **Configurable concurrency**: download worker count is now set via `HARVEST_MAX_WORKERS` (default 8, was hardcoded 3) so it can be tuned per host.
- **Shared drain loop**: the accumulate + flush + progress-logging pattern is centralized in `Harvester.drain_futures`, replacing near-duplicate `ThreadPoolExecutor` blocks across all four harvesters (CMR, CATDS, NSIDC, OSISAF).
- **Faster checksums**: `md5()` reads in 1 MB chunks instead of 4 KB.